### PR TITLE
Fix event ordering

### DIFF
--- a/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-showcase.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-showcase.tsx
@@ -58,12 +58,6 @@ export function EventShowcase({
     return colors[tag];
   };
 
-  events.sort(
-    (a, b) =>
-      new Date(a.start_datetime).getTime() -
-      new Date(b.start_datetime).getTime(),
-  );
-
   const mostRecent = events[0];
 
   if (!mostRecent) {

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -32,8 +32,6 @@ export default async function MemberDashboard({
     api.duesPayment.validatePaidDues(),
   ]);
 
-  console.log("events: ", events);
-
   if (events.status === "rejected" || dues.status === "rejected") {
     return (
       <div className="mt-10 flex flex-col items-center justify-center gap-y-6 font-bold">

--- a/packages/api/src/routers/member.ts
+++ b/packages/api/src/routers/member.ts
@@ -11,6 +11,7 @@ import {
 import {
   and,
   count,
+  desc,
   eq,
   exists,
   getTableColumns,
@@ -215,6 +216,7 @@ export const memberRouter = {
       .where(
         and(eq(Member.userId, ctx.session.user.id), isNull(Event.hackathonId)),
       )
+      .orderBy(desc(Event.start_datetime))
       .groupBy(Event.id);
 
     return events;


### PR DESCRIPTION
# Why
More recently attended events need to come first

# What
Fixes the event ordering

# Test Plan
pull locally and sign yourself into events and look at the ordering
<img width="1458" alt="Screenshot 2025-01-06 at 3 10 54 PM" src="https://github.com/user-attachments/assets/af1b68b6-831c-4cb9-89fe-bc757771da47" />
<img width="1458" alt="Screenshot 2025-01-06 at 3 11 03 PM" src="https://github.com/user-attachments/assets/4ae3a4ad-3c3d-40ae-9cfc-e3ba6c8b0c37" />

