### PR TITLE
Blade/app error fix

### DIFF
--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -32,10 +32,15 @@ export const discord = new REST({ version: "10" }).setToken(
 export const stripe = new Stripe(env.STRIPE_SECRET_KEY, { typescript: true });
 
 export const isDiscordAdmin = async (user: Session["user"]) => {
-  const guildMember = (await discord.get(
-    Routes.guildMember(KNIGHTHACKS_GUILD_ID, user.discordUserId),
-  )) as APIGuildMember;
-  return guildMember.roles.includes(DISCORD_ADMIN_ROLE_ID);
+  try {
+    const guildMember = (await discord.get(
+      Routes.guildMember(KNIGHTHACKS_GUILD_ID, user.discordUserId),
+    )) as APIGuildMember;
+    return guildMember.roles.includes(DISCORD_ADMIN_ROLE_ID);
+  } catch (err) {
+    console.error("Error: ", err);
+    return false;
+  }
 };
 
 const GOOGLE_PRIVATE_KEY = Buffer.from(env.GOOGLE_PRIVATE_KEY_B64, "base64")


### PR DESCRIPTION
# Why
People not in the knighthacks discord aren't able to use blade due to a flaw in the isAdmin logic

# What
I added a try catch to the isAdmin function to catch any errors when it comes to fetching knighthacks members

# Test Plan
I left the test KH server and tested blade
