### PR TITLE
Make auth user email optional

### DIFF
--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -42,7 +42,7 @@ export const authConfig = {
         return {
           discordUserId: profile.id,
           name: profile.username,
-          email: profile.email ?? "",
+          email: profile.email,
           image: profile.avatar,
           id: profile.id,
         };

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -42,7 +42,7 @@ export const authConfig = {
         return {
           discordUserId: profile.id,
           name: profile.username,
-          email: profile.email,
+          email: profile.email ?? "",
           image: profile.avatar,
           id: profile.id,
         };

--- a/packages/db/src/schemas/auth.ts
+++ b/packages/db/src/schemas/auth.ts
@@ -9,6 +9,8 @@ export const User = createTable("user", (t) => ({
   id: t.uuid().notNull().primaryKey().defaultRandom(),
   discordUserId: t.varchar({ length: 255 }).notNull(),
   name: t.varchar({ length: 255 }),
+  email: t.varchar({ length: 255 }).notNull(),
+  emailVerified: t.timestamp({ mode: "date", withTimezone: true }),
   image: t.varchar({ length: 255 }),
 }));
 

--- a/packages/db/src/schemas/auth.ts
+++ b/packages/db/src/schemas/auth.ts
@@ -9,8 +9,6 @@ export const User = createTable("user", (t) => ({
   id: t.uuid().notNull().primaryKey().defaultRandom(),
   discordUserId: t.varchar({ length: 255 }).notNull(),
   name: t.varchar({ length: 255 }),
-  email: t.varchar({ length: 255 }).notNull(),
-  emailVerified: t.timestamp({ mode: "date", withTimezone: true }),
   image: t.varchar({ length: 255 }),
 }));
 

--- a/packages/db/src/schemas/auth.ts
+++ b/packages/db/src/schemas/auth.ts
@@ -9,7 +9,7 @@ export const User = createTable("user", (t) => ({
   id: t.uuid().notNull().primaryKey().defaultRandom(),
   discordUserId: t.varchar({ length: 255 }).notNull(),
   name: t.varchar({ length: 255 }),
-  email: t.varchar({ length: 255 }).notNull(),
+  email: t.varchar({ length: 255 }),
   emailVerified: t.timestamp({ mode: "date", withTimezone: true }),
   image: t.varchar({ length: 255 }),
 }));


### PR DESCRIPTION
# Why
Users that signed up for discord without a user email will get an authentication error upon sign in

# What
Added null checking for these accounts

# Test Plan
Created a discord account through the mobile app and tried to sign in to blade with it
