### PR TITLE
Changed size of dropdown menu item icons

### DIFF
--- a/apps/blade/src/app/_components/navigation/reuseable-user-dropdown.tsx
+++ b/apps/blade/src/app/_components/navigation/reuseable-user-dropdown.tsx
@@ -1,6 +1,6 @@
 import { CalendarDays, Settings, ShieldCheck, User } from "lucide-react";
 
-import { DASHBOARD_ICON_SIZE, USER_DROPDOWN_ICON_COLOR } from "~/consts";
+import { USER_DROPDOWN_ICON_COLOR, USER_DROPDOWN_ICON_SIZE } from "~/consts";
 
 /*
  * name = the text to be displayed
@@ -21,7 +21,7 @@ export const adminItems: roleItems[] = [
     component: (
       <ShieldCheck
         color={USER_DROPDOWN_ICON_COLOR}
-        size={DASHBOARD_ICON_SIZE}
+        size={USER_DROPDOWN_ICON_SIZE}
       />
     ),
     route: "/admin",
@@ -29,7 +29,7 @@ export const adminItems: roleItems[] = [
   {
     name: "Members",
     component: (
-      <User color={USER_DROPDOWN_ICON_COLOR} size={DASHBOARD_ICON_SIZE} />
+      <User color={USER_DROPDOWN_ICON_COLOR} size={USER_DROPDOWN_ICON_SIZE} />
     ),
     route: "/admin/members",
   },
@@ -38,7 +38,7 @@ export const adminItems: roleItems[] = [
     component: (
       <CalendarDays
         color={USER_DROPDOWN_ICON_COLOR}
-        size={DASHBOARD_ICON_SIZE}
+        size={USER_DROPDOWN_ICON_SIZE}
       />
     ),
     route: "/admin/events",
@@ -49,7 +49,10 @@ export const memberItems: roleItems[] = [
   {
     name: "Settings",
     component: (
-      <Settings color={USER_DROPDOWN_ICON_COLOR} size={DASHBOARD_ICON_SIZE} />
+      <Settings
+        color={USER_DROPDOWN_ICON_COLOR}
+        size={USER_DROPDOWN_ICON_SIZE}
+      />
     ),
     route: "/settings",
   },

--- a/apps/blade/src/app/_components/navigation/user-dropdown.tsx
+++ b/apps/blade/src/app/_components/navigation/user-dropdown.tsx
@@ -18,7 +18,7 @@ import {
 } from "@forge/ui/dropdown-menu";
 
 import type { roleItems } from "./reuseable-user-dropdown";
-import { DASHBOARD_ICON_SIZE, USER_DROPDOWN_ICON_COLOR } from "~/consts";
+import { USER_DROPDOWN_ICON_COLOR, USER_DROPDOWN_ICON_SIZE } from "~/consts";
 import { api } from "~/trpc/react";
 import { adminItems, memberItems } from "./reuseable-user-dropdown";
 
@@ -59,7 +59,7 @@ export function UserDropdown({
           >
             <LayoutDashboard
               color={USER_DROPDOWN_ICON_COLOR}
-              size={DASHBOARD_ICON_SIZE}
+              size={USER_DROPDOWN_ICON_SIZE}
             />
             <span>Dashboard</span>
           </DropdownMenuItem>

--- a/apps/blade/src/consts/index.ts
+++ b/apps/blade/src/consts/index.ts
@@ -10,3 +10,4 @@ export const SIDEBAR_NAV_ITEMS = [
 ];
 
 export const USER_DROPDOWN_ICON_COLOR = "hsl(263.4 70% 50.4%)"; //lucide only works with HSL values
+export const USER_DROPDOWN_ICON_SIZE = 20;


### PR DESCRIPTION
# Why

A size mismatch existed between the dropdown item text and the icons.

# What

Changed the icon size to 20 and moved to const.

# Test Plan

Verified output through UI
