### PR TITLE
add slider indicators

### DIFF
--- a/apps/blade/src/app/admin/events/_components/events-table.tsx
+++ b/apps/blade/src/app/admin/events/_components/events-table.tsx
@@ -153,13 +153,6 @@ export function EventsTable() {
           </TableRow>
         </TableHeader>
 
-        <TableCell
-          className="text- bg-muted/50 font-bold sm:text-center"
-          colSpan={8}
-        >
-          Upcoming Events
-        </TableCell>
-
         <TableBody>
           <TableRow>
             <TableCell

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-feedback.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-feedback.tsx
@@ -126,7 +126,10 @@ export function EventFeedbackForm({
           Give Feedback
         </Button>
       </DialogTrigger>
-      <DialogContent aria-describedby={undefined} className="max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        aria-describedby={undefined}
+        className="max-h-[80vh] overflow-y-auto"
+      >
         <DialogHeader>
           <DialogTitle>Your Feedback For {event.name}</DialogTitle>
         </DialogHeader>

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-feedback.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-feedback.tsx
@@ -123,7 +123,7 @@ export function EventFeedbackForm({
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" disabled={isFeedbackGiven}>
-          Give Feedback
+          Feedback
         </Button>
       </DialogTrigger>
       <DialogContent

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-feedback.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-feedback.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2, MessageCircle } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { z } from "zod";
 
 import type { InsertMember, SelectEvent } from "@forge/db/schemas/knight-hacks";
@@ -122,11 +122,11 @@ export function EventFeedbackForm({
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" disabled={isFeedbackGiven}>
-          <MessageCircle className="h-5 w-5" />
+        <Button variant="outline" size="sm" disabled={isFeedbackGiven}>
+          Give Feedback
         </Button>
       </DialogTrigger>
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent aria-describedby={undefined} className="max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Your Feedback For {event.name}</DialogTitle>
         </DialogHeader>

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-showcase.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-showcase.tsx
@@ -71,7 +71,7 @@ export function EventShowcase({
             </CardDescription>
           </div>
           <Badge className={`${getTagColor(mostRecent.tag)} my-auto`}>
-              {mostRecent.tag}
+            {mostRecent.tag}
           </Badge>
         </div>
       </CardHeader>
@@ -113,7 +113,7 @@ export function EventShowcase({
           <DialogTrigger asChild>
             <Button variant="outline">View All</Button>
           </DialogTrigger>
-          <DialogContent className="max-h-[80vh] overflow-y-auto max-w-2xl">
+          <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Past Events Attended</DialogTitle>
             </DialogHeader>
@@ -129,7 +129,7 @@ export function EventShowcase({
                         </CardDescription>
                       </div>
                       <Badge className={`${getTagColor(event.tag)} my-auto`}>
-                          {event.tag}
+                        {event.tag}
                       </Badge>
                     </div>
                   </CardHeader>
@@ -171,7 +171,6 @@ export function EventShowcase({
                           <EventFeedbackForm event={event} member={member} />
                         </div>
                       </div>
-
                     </div>
                   </CardContent>
                 </Card>

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-showcase.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/event/event-showcase.tsx
@@ -70,14 +70,9 @@ export function EventShowcase({
               {mostRecent.description}
             </CardDescription>
           </div>
-          <div className="flex flex-row gap-2">
-            <div>
-              <EventFeedbackForm event={mostRecent} member={member} />
-            </div>
-            <Badge className={`${getTagColor(mostRecent.tag)} my-auto`}>
+          <Badge className={`${getTagColor(mostRecent.tag)} my-auto`}>
               {mostRecent.tag}
-            </Badge>
-          </div>
+          </Badge>
         </div>
       </CardHeader>
       <CardContent>
@@ -100,13 +95,16 @@ export function EventShowcase({
               {mostRecent.numAttended === 1 ? "Attendee" : "Attendees"}
             </span>
           </div>
-          <div>
+          <div className="flex flex-row justify-between">
             {mostRecent.points && (
               <div className="flex items-center gap-2">
                 <Star className="h-5 w-5 text-yellow-500" />
                 <span>{mostRecent.points} Points</span>
               </div>
             )}
+            <div>
+              <EventFeedbackForm event={mostRecent} member={member} />
+            </div>
           </div>
         </div>
       </CardContent>
@@ -115,7 +113,7 @@ export function EventShowcase({
           <DialogTrigger asChild>
             <Button variant="outline">View All</Button>
           </DialogTrigger>
-          <DialogContent className="max-w-2xl">
+          <DialogContent className="max-h-[80vh] overflow-y-auto max-w-2xl">
             <DialogHeader>
               <DialogTitle>Past Events Attended</DialogTitle>
             </DialogHeader>
@@ -130,14 +128,9 @@ export function EventShowcase({
                           {event.description}
                         </CardDescription>
                       </div>
-                      <div className="flex flex-row gap-2">
-                        <div>
-                          <EventFeedbackForm event={event} member={member} />
-                        </div>
-                        <Badge className={`${getTagColor(event.tag)} my-auto`}>
+                      <Badge className={`${getTagColor(event.tag)} my-auto`}>
                           {event.tag}
-                        </Badge>
-                      </div>
+                      </Badge>
                     </div>
                   </CardHeader>
                   <CardContent>
@@ -162,17 +155,23 @@ export function EventShowcase({
                           {event.numAttended === 1 ? "Attendee" : "Attendees"}
                         </span>
                       </div>
-                      {event.points ? (
-                        <div className="flex items-center gap-2">
-                          <Star className="h-4 w-4 text-yellow-500" />
-                          <span>{event.points} Points</span>
+                      <div className="flex flex-row justify-between">
+                        {event.points ? (
+                          <div className="flex items-center gap-2">
+                            <Star className="h-4 w-4 text-yellow-500" />
+                            <span>{event.points} Points</span>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-2">
+                            <Star className="h-4 w-4 text-yellow-500" />
+                            <span>0 Points</span>
+                          </div>
+                        )}
+                        <div>
+                          <EventFeedbackForm event={event} member={member} />
                         </div>
-                      ) : (
-                        <div className="flex items-center gap-2">
-                          <Star className="h-4 w-4 text-yellow-500" />
-                          <span>0 Points</span>
-                        </div>
-                      )}
+                      </div>
+
                     </div>
                   </CardContent>
                 </Card>

--- a/packages/ui/src/slider.tsx
+++ b/packages/ui/src/slider.tsx
@@ -8,19 +8,23 @@ import { cn } from "@forge/ui";
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+>(({ className, value, onValueChange, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
       "relative flex w-full touch-none select-none items-center",
       className,
     )}
+    value={value}
+    onValueChange={onValueChange}
     {...props}
   >
     <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="flex items-center justify-center block text-xs h-5 w-5 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50">
+      {value?.[0] ?? 5}
+    </SliderPrimitive.Thumb>
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/packages/ui/src/slider.tsx
+++ b/packages/ui/src/slider.tsx
@@ -22,7 +22,7 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="flex items-center justify-center block text-xs h-5 w-5 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50">
+    <SliderPrimitive.Thumb className="block flex h-5 w-5 items-center justify-center rounded-full border border-primary/50 bg-background text-xs shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50">
       {value?.[0] ?? 5}
     </SliderPrimitive.Thumb>
   </SliderPrimitive.Root>


### PR DESCRIPTION
# Why

we needed slider indicators
and some small ui fixes

# What

fixed a ui error on the events table
changed the look of the feedback form button
moved feedback form button down
added indicators to the slider
adjusted some modals for responsiveness (made them scrollable)

# Test Plan

pull and test

media:
![image](https://github.com/user-attachments/assets/009f6b52-7ef4-498e-9f85-03864c43c46d)
![image](https://github.com/user-attachments/assets/57c78029-ce2f-4a2c-9587-6bb6e97e9f97)
![image](https://github.com/user-attachments/assets/ffd8f66b-cf1f-48f0-854a-4bf36c2a88ea)
![image](https://github.com/user-attachments/assets/5c67c9c7-c28a-47c4-a4e8-5a83fffa87cd)
