### PR TITLE
[Club] Optimize home page data fetching and processing

### DIFF
--- a/apps/club/src/app/_components/landing/calendar.tsx
+++ b/apps/club/src/app/_components/landing/calendar.tsx
@@ -14,11 +14,26 @@ import TerminalSVG from "./assets/terminal";
 
 import "rsuite/Calendar/styles/index.css";
 
+import type { RouterOutputs } from "@forge/api";
+
 export default function CalendarEventsPage({
   events,
 }: {
-  events: Map<string, ReturnEvent[]>;
+  events: RouterOutputs["event"]["getEvents"];
 }) {
+  const eventMap = new Map<string, ReturnEvent[]>();
+
+  events.forEach((event) => {
+    const day = event.start_datetime.getDate();
+    const month = event.start_datetime.getMonth();
+    const year = event.start_datetime.getFullYear();
+    const dateString = `${day}-${month}-${year}`;
+    if (!eventMap.has(dateString)) {
+      eventMap.set(dateString, []);
+    }
+    eventMap.get(dateString)?.push(event);
+  });
+
   gsap.registerPlugin(ScrollTrigger);
   const [selectedDate, setSelectedDate] = React.useState<Date | null>(null);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -51,7 +66,7 @@ export default function CalendarEventsPage({
     const day = date.getDate();
     const month = date.getMonth();
     const year = date.getFullYear();
-    return events.get(`${day}-${month}-${year}`) ?? [];
+    return eventMap.get(`${day}-${month}-${year}`) ?? [];
   }
 
   function renderCell(date: Date) {

--- a/apps/club/src/app/page.tsx
+++ b/apps/club/src/app/page.tsx
@@ -1,5 +1,3 @@
-import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
-
 import { env } from "~/env";
 import About from "./_components/landing/about";
 import CalendarPage from "./_components/landing/calendar";
@@ -10,21 +8,10 @@ import Sponsors from "./_components/landing/sponsors";
 import { api } from "./trpc/server";
 
 export default async function HomePage() {
-  const events = await api.event.getEvents.query();
-  const memberCount = await api.member.getMemberCount.query();
-
-  const eventMap = new Map<string, ReturnEvent[]>();
-
-  events.forEach((event) => {
-    const day = event.start_datetime.getDate();
-    const month = event.start_datetime.getMonth();
-    const year = event.start_datetime.getFullYear();
-    const dateString = `${day}-${month}-${year}`;
-    if (!eventMap.has(dateString)) {
-      eventMap.set(dateString, []);
-    }
-    eventMap.get(dateString)?.push(event);
-  });
+  const [events, memberCount] = await Promise.all([
+    api.event.getEvents.query(),
+    api.member.getMemberCount.query(),
+  ]);
 
   return (
     <div className="bg-[#0F172A]">
@@ -32,7 +19,7 @@ export default async function HomePage() {
       <About />
       <Impact />
       <Sponsors />
-      <CalendarPage events={eventMap} />
+      <CalendarPage events={events} />
       <Discover memberCount={memberCount} />
     </div>
   );


### PR DESCRIPTION
# Why

Home page suffers from slow page loads likely due to waterfalls caused by 2 round trips to the server 

# What

This PR batches the api calls to retrieve events and the member count, and moved the processing of the events into the calendar page where the data is needed

# Test Plan|

> These delays do not accurately represent the performance of these APIs in prod as they are artificially created in dev per each request. This is intentional so we could catch unnecessary waterfalls caused by round-trip API calls like what was fixed in this PR. This performance test was also performed with caching disabled.

Before:
![image](https://github.com/user-attachments/assets/b50435c6-cb7b-4764-985c-4b79a3a3ef5f)


After:
![image](https://github.com/user-attachments/assets/9ede03a9-2bf3-4674-be12-ca192ef6e8e9)

The HomePage logs are the time it takes for all the server-side logic to execute before rendering the page. Notice how these logs are on average faster in the After image.
