### PR TITLE
Add no-console lint rule

### DIFF
--- a/apps/blade/src/app/admin/events/_components/view-attendance-button.tsx
+++ b/apps/blade/src/app/admin/events/_components/view-attendance-button.tsx
@@ -51,6 +51,7 @@ function Attendees({ eventId }: { eventId: string }) {
     }
 
     invalidateAttendees().catch((error) => {
+      // eslint-disable-next-line no-console
       console.error(
         "Error invalidating members in gathering attendees: ",
         error,

--- a/apps/blade/src/app/admin/members/_components/member-profile.tsx
+++ b/apps/blade/src/app/admin/members/_components/member-profile.tsx
@@ -38,6 +38,7 @@ export default function MemberProfileButton({
     }
 
     invalidateMembers().catch((error) => {
+      // eslint-disable-next-line no-console
       console.error("Error invalidating members in member profile: ", error);
     });
   }, [utils.member, member]);

--- a/apps/blade/src/app/api/membership/route.ts
+++ b/apps/blade/src/app/api/membership/route.ts
@@ -10,8 +10,6 @@ import { env } from "~/env";
 async function membershipRecord(sessionId: string) {
   const stripe = new Stripe(env.STRIPE_SECRET_KEY, { typescript: true });
 
-  
-
   // TODO: Make this function safe to run multiple times,
   // even concurrently, with the same session ID
 

--- a/apps/blade/src/app/api/membership/route.ts
+++ b/apps/blade/src/app/api/membership/route.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import type { NextRequest } from "next/server";
 import Stripe from "stripe";
 
@@ -9,7 +10,7 @@ import { env } from "~/env";
 async function membershipRecord(sessionId: string) {
   const stripe = new Stripe(env.STRIPE_SECRET_KEY, { typescript: true });
 
-  console.log("Fulfilling Checkout Session");
+  
 
   // TODO: Make this function safe to run multiple times,
   // even concurrently, with the same session ID

--- a/apps/blade/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/blade/src/app/api/trpc/[trpc]/route.ts
@@ -33,6 +33,7 @@ const handler = auth(async (req) => {
         headers: req.headers,
       }),
     onError({ error, path }) {
+      // eslint-disable-next-line no-console
       console.error(`>>> tRPC Error on '${path}'`, error);
     },
   });

--- a/apps/blade/src/app/hacker/application/_components/hacker-application-form.tsx
+++ b/apps/blade/src/app/hacker/application/_components/hacker-application-form.tsx
@@ -266,6 +266,7 @@ export function HackerFormPage() {
               resumeUrl,
             });
           } catch (error) {
+            // eslint-disable-next-line no-console
             console.error("Error uploading resume or creating hacker:", error);
             toast.error(
               "Something went wrong while processing your application.",

--- a/apps/blade/src/app/member/application/_components/member-application-form.tsx
+++ b/apps/blade/src/app/member/application/_components/member-application-form.tsx
@@ -236,6 +236,7 @@ export function MemberApplicationForm() {
               resumeUrl, // Include uploaded resume URL
             });
           } catch (error) {
+            // eslint-disable-next-line no-console
             console.error("Error uploading resume or creating member:", error);
             toast.error(
               "Something went wrong while processing your application.",

--- a/apps/blade/src/app/settings/hacker-profile/hacker-profile-form.tsx
+++ b/apps/blade/src/app/settings/hacker-profile/hacker-profile-form.tsx
@@ -285,6 +285,7 @@ export function HackerProfileForm({
                 resumeUrl, // Include uploaded resume URL
               });
             } catch (error) {
+              // eslint-disable-next-line no-console
               console.error(
                 "Error uploading resume or updating hacker:",
                 error,

--- a/apps/blade/src/app/settings/member-profile-form.tsx
+++ b/apps/blade/src/app/settings/member-profile-form.tsx
@@ -249,6 +249,7 @@ export function MemberProfileForm({
                 resumeUrl, // Include uploaded resume URL
               });
             } catch (error) {
+              // eslint-disable-next-line no-console
               console.error(
                 "Error uploading resume or updating member:",
                 error,

--- a/apps/club/src/app/_components/landing/impact-assets/wave-reveal.tsx
+++ b/apps/club/src/app/_components/landing/impact-assets/wave-reveal.tsx
@@ -211,7 +211,6 @@ export default function WaveReveal({
     blur,
     className: letterClassName,
   });
-  console.log("Text: ", text);
 
   return (
     <div

--- a/apps/tk/eslint.config.js
+++ b/apps/tk/eslint.config.js
@@ -7,4 +7,9 @@ export default [
   },
   ...baseConfig,
   ...restrictEnvAccess,
+  {
+    rules: {
+      "no-console": "off",
+    },
+  },
 ];

--- a/packages/api/eslint.config.js
+++ b/packages/api/eslint.config.js
@@ -9,7 +9,7 @@ export default [
   ...restrictEnvAccess,
   {
     rules: {
-      "@typescript-eslint/prefer-nullish-coalescing": "off",
+      "no-console": "off",
     },
   },
 ];

--- a/packages/api/src/routers/hacker.ts
+++ b/packages/api/src/routers/hacker.ts
@@ -114,7 +114,7 @@ export const hackerRouter = {
         });
       }
 
-      const resume = input.resumeUrl ? input.resumeUrl : hacker.resumeUrl;
+      const resume = input.resumeUrl ?? hacker.resumeUrl;
 
       // Check if the age has been updated
       const today = new Date();

--- a/packages/api/src/routers/member.ts
+++ b/packages/api/src/routers/member.ts
@@ -132,8 +132,7 @@ export const memberRouter = {
           code: "NOT_FOUND",
         });
       }
-
-      const resume = input.resumeUrl ? input.resumeUrl : member.resumeUrl;
+      const resume = input.resumeUrl ?? member.resumeUrl;
 
       // Check if the age has been updated
       const today = new Date();

--- a/tooling/eslint/base.js
+++ b/tooling/eslint/base.js
@@ -75,6 +75,7 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-non-null-assertion": "error",
       "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+      "no-console": "warn",
     },
   },
   {


### PR DESCRIPTION
# Why

Temporary console log statements tend to pollute the console tab in browser dev tools, which most times aren't necessary, especially if they aren't used to log important errors or information to devs. They can also potentially slow down our applications if they're placed in loops or done recursively.

# What

This PR adds a new base rule to our ESLint config that warns devs of uses of console.log statements.

# Test Plan

Nothing really to show case.
