### PR TITLE
Semester toggle for club event data dash

### DIFF
--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -10,7 +10,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@forge/ui/select";
-import { SEMESTER_START_DATES } from "@forge/consts/knight-hacks";
+import type { Semester } from "@forge/consts/knight-hacks";
+import { SEMESTER_START_DATES, ALL_DATES_RANGE_UNIX } from "@forge/consts/knight-hacks";
 
 import AttendancesBarChart from "./event-data/AttendancesBarChart";
 import AttendancesMobile from "./event-data/AttendancesMobile";
@@ -20,7 +21,9 @@ import { WeekdayPopularityRadar } from "./event-data/WeekdayPopularityRadar";
 
 export default function EventDemographics() {
   const { data: events } = api.event.getEvents.useQuery();
-  const [activeSemester, setActiveSemester] = useState<string | null>(null);
+  const [activeSemester, setActiveSemester] = useState<Semester | null>(null);
+
+  const semestersArr: Semester[] = [{name: "All", startDate: new Date(ALL_DATES_RANGE_UNIX.start), endDate: new Date(ALL_DATES_RANGE_UNIX.end)}]; // for select options
 
   const semestersSet = new Set<string>();
   events?.forEach(({start_datetime}) => {
@@ -30,27 +33,41 @@ export default function EventDemographics() {
     const fallStart = new Date(`${year}-${SEMESTER_START_DATES.fall.month + 1}-${SEMESTER_START_DATES.fall.day}`);
 
     // keep track of semesters that exist in events table of db
-    if (start_datetime >= springStart && start_datetime < summerStart)
-      semestersSet.add(`Spring ${year}`);
-    else if (start_datetime >= summerStart && start_datetime < fallStart)
-      semestersSet.add(`Summer ${year}`);
-    else if (start_datetime >= fallStart && start_datetime < new Date(`${year+1}-1-1`))
-      semestersSet.add(`Fall ${year}`);
-    else
-      semestersSet.add("No semester");
+    if (start_datetime >= springStart && start_datetime < summerStart) {
+      const semesterName = `Spring ${year}`;
+      if (!semestersSet.has(semesterName)) {
+        semestersSet.add(semesterName);
+        const springEnd = new Date(`${year}-${SEMESTER_START_DATES.summer.month + 1}-${SEMESTER_START_DATES.summer.day}`);
+        semestersArr.push({name: semesterName, startDate: springStart, endDate: springEnd});
+      }
+    }
+    else if (start_datetime >= summerStart && start_datetime < fallStart) {
+      const semesterName = `Summer ${year}`;
+      if (!semestersSet.has(semesterName)) {
+        semestersSet.add(semesterName);
+        const summerEnd = new Date(`${year}-${SEMESTER_START_DATES.fall.month + 1}-${SEMESTER_START_DATES.fall.day}`);
+        semestersArr.push({name: semesterName, startDate: summerStart, endDate: summerEnd});
+      }
+    }
+    else if (start_datetime >= fallStart && start_datetime < new Date(`${year+1}-1-1`)) {
+      const semesterName = `Fall ${year}`;
+      if (!semestersSet.has(semesterName)) {
+        semestersSet.add(semesterName);
+        const fallEnd = new Date(`${year + 1}-${SEMESTER_START_DATES.spring.month + 1}-${SEMESTER_START_DATES.spring.day}`);
+        semestersArr.push({name: semesterName, startDate: fallStart, endDate: fallEnd});
+      }
+    }
   });
-
-  const semestersArr = ["All", ...semestersSet]; // for select options
 
   return (
     <div className="my-6">
       {events && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
           <Select 
-            value={activeSemester ?? undefined}
+            value={activeSemester?.name ?? undefined}
             onValueChange={(semester) => {
               const selectedSemester =
-                semestersArr.find((s) => s === semester) ?? null;
+                semestersArr.find(({name}) => name === semester) ?? null;
               setActiveSemester(selectedSemester);
             }}
           >
@@ -62,21 +79,21 @@ export default function EventDemographics() {
             </SelectTrigger>
             <SelectContent>
               {semestersArr.map((semester) => (
-                <SelectItem key={semester} value={semester}>
-                  {semester} <span className="me-2" />
+                <SelectItem key={semester.name} value={semester.name}>
+                  {semester.name} <span className="me-2" />
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
-          <PopularityRanking events={events} />
+          <PopularityRanking events={events} semester={activeSemester} />
 
           {/* visible on large/medium screens */}
-          <AttendancesBarChart className="hidden lg:block" events={events} />
+          <AttendancesBarChart className="hidden lg:block" events={events} semester={activeSemester} />
           {/* visible on mobile (small) screens only */}
-          <AttendancesMobile className="lg:hidden" events={events} />
+          <AttendancesMobile className="lg:hidden" events={events} semester={activeSemester} />
 
-          <TypePie events={events} />
-          <WeekdayPopularityRadar events={events} />
+          <TypePie events={events} semester={activeSemester} />
+          <WeekdayPopularityRadar events={events} semester={activeSemester} />
         </div>
       )}
     </div>

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -69,8 +69,8 @@ export default function EventDemographics() {
   return (
     <div className="my-6">
       {events && (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-          <Select 
+        <div className="grid gap-4">
+          <Select
             value={activeSemester?.name ?? undefined}
             onValueChange={(semester) => {
               const selectedSemester =
@@ -94,7 +94,7 @@ export default function EventDemographics() {
           </Select>
           {
             filteredEvents && filteredEvents.length > 0 ? 
-            <>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
               <PopularityRanking events={filteredEvents} />
 
               {/* visible on large/medium screens */}
@@ -104,9 +104,9 @@ export default function EventDemographics() {
 
               <TypePie events={filteredEvents} />
               <WeekdayPopularityRadar events={filteredEvents} />
-            </>
+            </div>
             :
-            <p>nothing</p>
+            <p className="mt-20 text-center text-slate-300">No events found for the selected semester!</p>
           }
         </div>
       )}

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -60,6 +60,12 @@ export default function EventDemographics() {
     }
   });
 
+  const filteredEvents = events?.filter(event => {
+    if (activeSemester)
+      return event.start_datetime > activeSemester.startDate && event.start_datetime < activeSemester.endDate;
+    return true;
+  });
+
   return (
     <div className="my-6">
       {events && (
@@ -86,15 +92,22 @@ export default function EventDemographics() {
               ))}
             </SelectContent>
           </Select>
-          <PopularityRanking events={events} semester={activeSemester} />
+          {
+            filteredEvents && filteredEvents.length > 0 ? 
+            <>
+              <PopularityRanking events={filteredEvents} />
 
-          {/* visible on large/medium screens */}
-          <AttendancesBarChart className="hidden lg:block" events={events} semester={activeSemester} />
-          {/* visible on mobile (small) screens only */}
-          <AttendancesMobile className="lg:hidden" events={events} semester={activeSemester} />
+              {/* visible on large/medium screens */}
+              <AttendancesBarChart className="hidden lg:block" events={filteredEvents} />
+              {/* visible on mobile (small) screens only */}
+              <AttendancesMobile className="lg:hidden" events={filteredEvents} />
 
-          <TypePie events={events} semester={activeSemester} />
-          <WeekdayPopularityRadar events={events} semester={activeSemester} />
+              <TypePie events={filteredEvents} />
+              <WeekdayPopularityRadar events={filteredEvents} />
+            </>
+            :
+            <p>nothing</p>
+          }
         </div>
       )}
     </div>

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -64,7 +64,7 @@ export default function EventDemographics() {
     if (activeSemester)
       return event.start_datetime > activeSemester.startDate && event.start_datetime < activeSemester.endDate;
     return true;
-  });
+  }).sort((a, b) => a.tag > b.tag ? 1 : a.tag < b.tag ? -1 : 0); // ensure same order of tags
 
   return (
     <div className="my-6">

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { api } from "~/trpc/react";
+import { useEffect, useState } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@forge/ui/select";
 import AttendancesBarChart from "./event-data/AttendancesBarChart";
 import AttendancesMobile from "./event-data/AttendancesMobile";
 import PopularityRanking from "./event-data/PopularityRanking";
@@ -9,11 +18,36 @@ import { WeekdayPopularityRadar } from "./event-data/WeekdayPopularityRadar";
 
 export default function EventDemographics() {
   const { data: events } = api.event.getEvents.useQuery();
+  const [activeSemester, setActiveSemester] = useState<string | null>(null);
+
+  const placeholderSemesters = ["spring", "summer", "fall"];
 
   return (
     <div className="my-6">
       {events && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
+          <Select 
+            value={activeSemester ?? undefined}
+            onValueChange={(semester) => {
+              const selectedSemester =
+                placeholderSemesters.find((s) => s === semester) ?? null;
+              setActiveSemester(selectedSemester);
+            }}
+          >
+            <SelectTrigger
+              className="md:w-1/2 lg:w-1/2"
+              aria-label="Select a value"
+            >
+              <SelectValue placeholder="Select semester" />
+            </SelectTrigger>
+            <SelectContent>
+              {placeholderSemesters.map((semester) => (
+                <SelectItem key={semester} value={semester}>
+                  {semester} <span className="me-2" />
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <PopularityRanking events={events} />
 
           {/* visible on large/medium screens */}

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -17,12 +17,9 @@ export default function EventDemographics() {
           <PopularityRanking events={events} />
 
           {/* visible on large/medium screens */}
-          <AttendancesBarChart
-            className="hidden md:block lg:block"
-            events={events}
-          />
+          <AttendancesBarChart className="hidden lg:block" events={events} />
           {/* visible on mobile (small) screens only */}
-          <AttendancesMobile className="md:hidden lg:hidden" events={events} />
+          <AttendancesMobile className="lg:hidden" events={events} />
 
           <TypePie events={events} />
           <WeekdayPopularityRadar events={events} />

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -21,9 +21,10 @@ import { WeekdayPopularityRadar } from "./event-data/WeekdayPopularityRadar";
 
 export default function EventDemographics() {
   const { data: events } = api.event.getEvents.useQuery();
-  const [activeSemester, setActiveSemester] = useState<Semester | null>(null);
+    const semestersArr: Semester[] = [{name: "All", startDate: new Date(ALL_DATES_RANGE_UNIX.start), endDate: new Date(ALL_DATES_RANGE_UNIX.end)}]; // for select options
 
-  const semestersArr: Semester[] = [{name: "All", startDate: new Date(ALL_DATES_RANGE_UNIX.start), endDate: new Date(ALL_DATES_RANGE_UNIX.end)}]; // for select options
+  const defaultSemester = semestersArr[0] ?? null;
+  const [activeSemester, setActiveSemester] = useState<Semester | null>(defaultSemester);
 
   const semestersSet = new Set<string>();
   events?.forEach(({start_datetime}) => {

--- a/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/EventDemographics.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { api } from "~/trpc/react";
 import { useState } from "react";
 
+import type { Semester } from "@forge/consts/knight-hacks";
+import {
+  ALL_DATES_RANGE_UNIX,
+  SEMESTER_START_DATES,
+} from "@forge/consts/knight-hacks";
 import {
   Select,
   SelectContent,
@@ -10,9 +14,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@forge/ui/select";
-import type { Semester } from "@forge/consts/knight-hacks";
-import { SEMESTER_START_DATES, ALL_DATES_RANGE_UNIX } from "@forge/consts/knight-hacks";
 
+import { api } from "~/trpc/react";
 import AttendancesBarChart from "./event-data/AttendancesBarChart";
 import AttendancesMobile from "./event-data/AttendancesMobile";
 import PopularityRanking from "./event-data/PopularityRanking";
@@ -21,50 +24,88 @@ import { WeekdayPopularityRadar } from "./event-data/WeekdayPopularityRadar";
 
 export default function EventDemographics() {
   const { data: events } = api.event.getEvents.useQuery();
-    const semestersArr: Semester[] = [{name: "All", startDate: new Date(ALL_DATES_RANGE_UNIX.start), endDate: new Date(ALL_DATES_RANGE_UNIX.end)}]; // for select options
+  const semestersArr: Semester[] = [
+    {
+      name: "All",
+      startDate: new Date(ALL_DATES_RANGE_UNIX.start),
+      endDate: new Date(ALL_DATES_RANGE_UNIX.end),
+    },
+  ]; // for select options
 
   const defaultSemester = semestersArr[0] ?? null;
-  const [activeSemester, setActiveSemester] = useState<Semester | null>(defaultSemester);
+  const [activeSemester, setActiveSemester] = useState<Semester | null>(
+    defaultSemester,
+  );
 
   const semestersSet = new Set<string>();
-  events?.forEach(({start_datetime}) => {
+  events?.forEach(({ start_datetime }) => {
     const year = start_datetime.getFullYear();
-    const springStart = new Date(`${year}-${SEMESTER_START_DATES.spring.month + 1}-${SEMESTER_START_DATES.spring.day}`);
-    const summerStart = new Date(`${year}-${SEMESTER_START_DATES.summer.month + 1}-${SEMESTER_START_DATES.summer.day}`);
-    const fallStart = new Date(`${year}-${SEMESTER_START_DATES.fall.month + 1}-${SEMESTER_START_DATES.fall.day}`);
+    const springStart = new Date(
+      `${year}-${SEMESTER_START_DATES.spring.month + 1}-${SEMESTER_START_DATES.spring.day}`,
+    );
+    const summerStart = new Date(
+      `${year}-${SEMESTER_START_DATES.summer.month + 1}-${SEMESTER_START_DATES.summer.day}`,
+    );
+    const fallStart = new Date(
+      `${year}-${SEMESTER_START_DATES.fall.month + 1}-${SEMESTER_START_DATES.fall.day}`,
+    );
 
     // keep track of semesters that exist in events table of db
     if (start_datetime >= springStart && start_datetime < summerStart) {
       const semesterName = `Spring ${year}`;
       if (!semestersSet.has(semesterName)) {
         semestersSet.add(semesterName);
-        const springEnd = new Date(`${year}-${SEMESTER_START_DATES.summer.month + 1}-${SEMESTER_START_DATES.summer.day}`);
-        semestersArr.push({name: semesterName, startDate: springStart, endDate: springEnd});
+        const springEnd = new Date(
+          `${year}-${SEMESTER_START_DATES.summer.month + 1}-${SEMESTER_START_DATES.summer.day}`,
+        );
+        semestersArr.push({
+          name: semesterName,
+          startDate: springStart,
+          endDate: springEnd,
+        });
       }
-    }
-    else if (start_datetime >= summerStart && start_datetime < fallStart) {
+    } else if (start_datetime >= summerStart && start_datetime < fallStart) {
       const semesterName = `Summer ${year}`;
       if (!semestersSet.has(semesterName)) {
         semestersSet.add(semesterName);
-        const summerEnd = new Date(`${year}-${SEMESTER_START_DATES.fall.month + 1}-${SEMESTER_START_DATES.fall.day}`);
-        semestersArr.push({name: semesterName, startDate: summerStart, endDate: summerEnd});
+        const summerEnd = new Date(
+          `${year}-${SEMESTER_START_DATES.fall.month + 1}-${SEMESTER_START_DATES.fall.day}`,
+        );
+        semestersArr.push({
+          name: semesterName,
+          startDate: summerStart,
+          endDate: summerEnd,
+        });
       }
-    }
-    else if (start_datetime >= fallStart && start_datetime < new Date(`${year+1}-1-1`)) {
+    } else if (
+      start_datetime >= fallStart &&
+      start_datetime < new Date(`${year + 1}-1-1`)
+    ) {
       const semesterName = `Fall ${year}`;
       if (!semestersSet.has(semesterName)) {
         semestersSet.add(semesterName);
-        const fallEnd = new Date(`${year + 1}-${SEMESTER_START_DATES.spring.month + 1}-${SEMESTER_START_DATES.spring.day}`);
-        semestersArr.push({name: semesterName, startDate: fallStart, endDate: fallEnd});
+        const fallEnd = new Date(
+          `${year + 1}-${SEMESTER_START_DATES.spring.month + 1}-${SEMESTER_START_DATES.spring.day}`,
+        );
+        semestersArr.push({
+          name: semesterName,
+          startDate: fallStart,
+          endDate: fallEnd,
+        });
       }
     }
   });
 
-  const filteredEvents = events?.filter(event => {
-    if (activeSemester)
-      return event.start_datetime > activeSemester.startDate && event.start_datetime < activeSemester.endDate;
-    return true;
-  }).sort((a, b) => a.tag > b.tag ? 1 : a.tag < b.tag ? -1 : 0); // ensure same order of tags
+  const filteredEvents = events
+    ?.filter((event) => {
+      if (activeSemester)
+        return (
+          event.start_datetime > activeSemester.startDate &&
+          event.start_datetime < activeSemester.endDate
+        );
+      return true;
+    })
+    .sort((a, b) => (a.tag > b.tag ? 1 : a.tag < b.tag ? -1 : 0)); // ensure same order of tags
 
   return (
     <div className="my-6">
@@ -74,7 +115,7 @@ export default function EventDemographics() {
             value={activeSemester?.name ?? undefined}
             onValueChange={(semester) => {
               const selectedSemester =
-                semestersArr.find(({name}) => name === semester) ?? null;
+                semestersArr.find(({ name }) => name === semester) ?? null;
               setActiveSemester(selectedSemester);
             }}
           >
@@ -92,22 +133,29 @@ export default function EventDemographics() {
               ))}
             </SelectContent>
           </Select>
-          {
-            filteredEvents && filteredEvents.length > 0 ? 
+          {filteredEvents && filteredEvents.length > 0 ? (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
               <PopularityRanking events={filteredEvents} />
 
               {/* visible on large/medium screens */}
-              <AttendancesBarChart className="hidden lg:block" events={filteredEvents} />
+              <AttendancesBarChart
+                className="hidden lg:block"
+                events={filteredEvents}
+              />
               {/* visible on mobile (small) screens only */}
-              <AttendancesMobile className="lg:hidden" events={filteredEvents} />
+              <AttendancesMobile
+                className="lg:hidden"
+                events={filteredEvents}
+              />
 
               <TypePie events={filteredEvents} />
               <WeekdayPopularityRadar events={filteredEvents} />
             </div>
-            :
-            <p className="mt-20 text-center text-slate-300">No events found for the selected semester!</p>
-          }
+          ) : (
+            <p className="mt-20 text-center text-slate-300">
+              No events found for the selected semester!
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -126,7 +126,7 @@ export default function AttendancesBarChart({
             </BarChart>
           </ChartContainer>
           :
-          <p className="mt-20 text-center text-slate-300">No attendance data found</p>
+          <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
         }
       </CardContent>
     </Card>

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -26,7 +26,6 @@ export default function AttendancesBarChart({
   events: ReturnEvent[];
   className?: string;
 }) {
-  
   const baseConfig: ChartConfig = {
     events: { label: "events" },
   };
@@ -73,8 +72,7 @@ export default function AttendancesBarChart({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        {
-          avgAttendedData.length > 0 ?
+        {avgAttendedData.length > 0 ? (
           <ChartContainer config={baseConfig}>
             <BarChart
               accessibilityLayer
@@ -125,9 +123,11 @@ export default function AttendancesBarChart({
               </Bar>
             </BarChart>
           </ChartContainer>
-          :
-          <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
-        }
+        ) : (
+          <p className="mb-20 mt-16 text-center text-slate-300">
+            No attendance data found
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -73,56 +73,61 @@ export default function AttendancesBarChart({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={baseConfig}>
-          <BarChart
-            accessibilityLayer
-            data={avgAttendedData}
-            layout="vertical"
-            margin={{ right: 25 }}
-          >
-            <CartesianGrid horizontal={false} />
-            <YAxis
-              dataKey="tag"
-              type="category"
-              tickLine={false}
-              tickMargin={10}
-              axisLine={false}
-              hide
-            />
-            <XAxis
-              dataKey="avgAttendees"
-              type="number"
-              domain={[0, maxAttendees]}
-              hide
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent indicator="line" />}
-            />
-            <Bar
-              dataKey="avgAttendees"
-              name="Average attendees: "
+        {
+          maxAttendees > 0 ?
+          <ChartContainer config={baseConfig}>
+            <BarChart
+              accessibilityLayer
+              data={avgAttendedData}
               layout="vertical"
-              radius={4}
-              barSize={100}
+              margin={{ right: 25 }}
             >
-              <LabelList
+              <CartesianGrid horizontal={false} />
+              <YAxis
                 dataKey="tag"
-                position="insideLeft"
-                offset={8}
-                fontSize={12}
-                className="fill-[--color-label]"
+                type="category"
+                tickLine={false}
+                tickMargin={10}
+                axisLine={false}
+                hide
               />
-              <LabelList
+              <XAxis
                 dataKey="avgAttendees"
-                position="right"
-                offset={8}
-                fontSize={12}
-                className="fill-foreground"
+                type="number"
+                domain={[0, maxAttendees]}
+                hide
               />
-            </Bar>
-          </BarChart>
-        </ChartContainer>
+              <ChartTooltip
+                cursor={false}
+                content={<ChartTooltipContent indicator="line" />}
+              />
+              <Bar
+                dataKey="avgAttendees"
+                name="Average attendees: "
+                layout="vertical"
+                radius={4}
+                barSize={100}
+              >
+                <LabelList
+                  dataKey="tag"
+                  position="insideLeft"
+                  offset={8}
+                  fontSize={12}
+                  className="fill-[--color-label]"
+                />
+                <LabelList
+                  dataKey="avgAttendees"
+                  position="right"
+                  offset={8}
+                  fontSize={12}
+                  className="fill-foreground"
+                />
+              </Bar>
+            </BarChart>
+          </ChartContainer>
+          :
+          <p className="mt-20 text-center text-slate-300">No attendance data found</p>
+        }
       </CardContent>
     </Card>
   );

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -60,6 +60,10 @@ export default function AttendancesBarChart({
     }),
   );
 
+  const maxAttendees = Math.max(
+    ...avgAttendedData.map((d) => Number(d.avgAttendees)),
+  );
+
   return (
     <Card className={className}>
       <CardHeader>
@@ -69,7 +73,12 @@ export default function AttendancesBarChart({
       </CardHeader>
       <CardContent>
         <ChartContainer config={baseConfig}>
-          <BarChart accessibilityLayer data={avgAttendedData} layout="vertical">
+          <BarChart
+            accessibilityLayer
+            data={avgAttendedData}
+            layout="vertical"
+            margin={{ right: 25 }}
+          >
             <CartesianGrid horizontal={false} />
             <YAxis
               dataKey="tag"
@@ -79,7 +88,12 @@ export default function AttendancesBarChart({
               axisLine={false}
               hide
             />
-            <XAxis dataKey="avgAttendees" type="number" hide />
+            <XAxis
+              dataKey="avgAttendees"
+              type="number"
+              domain={[0, maxAttendees]}
+              hide
+            />
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent indicator="line" />}

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -11,8 +11,6 @@ import {
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
 import type { ChartConfig } from "@forge/ui/chart";
-import type {
-  Semester} from "@forge/consts/knight-hacks";
 import { ADMIN_PIE_CHART_COLORS } from "@forge/consts/knight-hacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 import {
@@ -24,13 +22,10 @@ import {
 export default function AttendancesBarChart({
   events,
   className,
-  semester,
 }: {
   events: ReturnEvent[];
   className?: string;
-  semester: Semester | null;
 }) {
-  if (semester) console.log(`AttendancesBarChart semester: ${JSON.stringify(semester)}`);
   
   const baseConfig: ChartConfig = {
     events: { label: "events" },

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -11,6 +11,8 @@ import {
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
 import type { ChartConfig } from "@forge/ui/chart";
+import type {
+  Semester} from "@forge/consts/knight-hacks";
 import { ADMIN_PIE_CHART_COLORS } from "@forge/consts/knight-hacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 import {
@@ -22,10 +24,14 @@ import {
 export default function AttendancesBarChart({
   events,
   className,
+  semester,
 }: {
   events: ReturnEvent[];
   className?: string;
+  semester: Semester | null;
 }) {
+  if (semester) console.log(`AttendancesBarChart semester: ${JSON.stringify(semester)}`);
+  
   const baseConfig: ChartConfig = {
     events: { label: "events" },
   };

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesBarChart.tsx
@@ -74,7 +74,7 @@ export default function AttendancesBarChart({
       </CardHeader>
       <CardContent>
         {
-          maxAttendees > 0 ?
+          avgAttendedData.length > 0 ?
           <ChartContainer config={baseConfig}>
             <BarChart
               accessibilityLayer

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
@@ -8,7 +8,6 @@ export default function AttendancesMobile({
   events: ReturnEvent[];
   className?: string;
 }) {
-  
   const tagData: Record<
     string,
     { totalAttendees: number; totalEvents: number }
@@ -38,19 +37,23 @@ export default function AttendancesMobile({
         </CardTitle>
       </CardHeader>
       <CardContent>
-      {avgAttendedData.length > 0 ? 
-        avgAttendedData.map((data) => (
-          <li
-            key={data.tag}
-            className="flex list-none justify-between border-b-2 border-dotted"
-          >
-            <span className="font-semibold text-fuchsia-700">{data.tag}:</span>
-            <span>{data.avgAttendees}</span>
-          </li>
-        ))
-        :
-        <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
-      }
+        {avgAttendedData.length > 0 ? (
+          avgAttendedData.map((data) => (
+            <li
+              key={data.tag}
+              className="flex list-none justify-between border-b-2 border-dotted"
+            >
+              <span className="font-semibold text-fuchsia-700">
+                {data.tag}:
+              </span>
+              <span>{data.avgAttendees}</span>
+            </li>
+          ))
+        ) : (
+          <p className="mb-20 mt-16 text-center text-slate-300">
+            No attendance data found
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
@@ -1,18 +1,13 @@
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
-import type {
-  Semester} from "@forge/consts/knight-hacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 
 export default function AttendancesMobile({
   events,
   className,
-  semester
 }: {
   events: ReturnEvent[];
   className?: string;
-  semester: Semester | null;
 }) {
-  if (semester) console.log(`AttendancesMobile semester: ${JSON.stringify(semester)}`);
   
   const tagData: Record<
     string,

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
@@ -1,13 +1,19 @@
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
+import type {
+  Semester} from "@forge/consts/knight-hacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 
 export default function AttendancesMobile({
   events,
   className,
+  semester
 }: {
   events: ReturnEvent[];
   className?: string;
+  semester: Semester | null;
 }) {
+  if (semester) console.log(`AttendancesMobile semester: ${JSON.stringify(semester)}`);
+  
   const tagData: Record<
     string,
     { totalAttendees: number; totalEvents: number }

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
@@ -49,7 +49,7 @@ export default function AttendancesMobile({
           </li>
         ))
         :
-        <p className="mt-20 text-center text-slate-300">No attendance data found</p>
+        <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
       }
       </CardContent>
     </Card>

--- a/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/AttendancesMobile.tsx
@@ -38,7 +38,8 @@ export default function AttendancesMobile({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        {avgAttendedData.map((data) => (
+      {avgAttendedData.length > 0 ? 
+        avgAttendedData.map((data) => (
           <li
             key={data.tag}
             className="flex list-none justify-between border-b-2 border-dotted"
@@ -46,7 +47,10 @@ export default function AttendancesMobile({
             <span className="font-semibold text-fuchsia-700">{data.tag}:</span>
             <span>{data.avgAttendees}</span>
           </li>
-        ))}
+        ))
+        :
+        <p className="mt-20 text-center text-slate-300">No attendance data found</p>
+      }
       </CardContent>
     </Card>
   );

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -13,6 +13,7 @@ export default function PopularityRanking({
   const [displayFullList, setDisplayFullList] = useState<boolean>(false);
 
   const topEvents = events
+    .filter(event => event.numAttended > 0)
     .sort((a, b) => b.numAttended - a.numAttended)
     .slice(0, 10);
 

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -1,27 +1,18 @@
 import { useState } from "react";
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
-import type {
-  Semester} from "@forge/consts/knight-hacks";
 import { RANKING_STYLES } from "@forge/consts/knight-hacks";
 import { Button } from "@forge/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 
 export default function PopularityRanking({
   events,
-  semester
 }: {
   events: ReturnEvent[];
-  semester: Semester | null;
 }) {
   const [displayFullList, setDisplayFullList] = useState<boolean>(false);
 
   const topEvents = events
-    .filter(event => {
-      if (semester)
-        return event.start_datetime > semester.startDate && event.start_datetime < semester.endDate;
-      return true; // consider all events if semester is null
-    })
     .sort((a, b) => b.numAttended - a.numAttended)
     .slice(0, 10);
 

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -13,7 +13,7 @@ export default function PopularityRanking({
   const [displayFullList, setDisplayFullList] = useState<boolean>(false);
 
   const topEvents = events
-    .filter(event => event.numAttended > 0)
+    .filter((event) => event.numAttended > 0)
     .sort((a, b) => b.numAttended - a.numAttended)
     .slice(0, 10);
 
@@ -25,8 +25,7 @@ export default function PopularityRanking({
         <CardTitle className="text-xl">Most Popular Events</CardTitle>
       </CardHeader>
       <CardContent>
-        {
-          topEvents.length > 0 ?
+        {topEvents.length > 0 ? (
           <ol className="mb-4 flex flex-col gap-2">
             {(displayFullList ? topEvents : topEvents.slice(0, 3)).map(
               (event, index: number) => (
@@ -35,23 +34,25 @@ export default function PopularityRanking({
                   className={`flex justify-between text-sm ${RANKING_STYLES[index] ?? "text-gray-400 md:text-base lg:text-base"}`}
                 >
                   <span className="me-4">
-                    {index + 1}. {event.name} &#91;{event.tag.toUpperCase()}&#93;
+                    {index + 1}. {event.name} &#91;{event.tag.toUpperCase()}
+                    &#93;
                   </span>
                   <span>{event.numAttended} attended</span>
                 </li>
               ),
             )}
           </ol>
-          :
-          <p className="mt-10 mb-14 text-center text-slate-300">No attendance data found</p>
-        }
+        ) : (
+          <p className="mb-14 mt-10 text-center text-slate-300">
+            No attendance data found
+          </p>
+        )}
         <div className="flex justify-center">
-        {
-          topEvents.length > 3 && // no need for show more toggle if there are 3 or less events
-          <Button variant="secondary" onClick={handleClick}>
-            {displayFullList ? "Show less" : "Show more"}
-          </Button>
-        }
+          {topEvents.length > 3 && ( // no need for show more toggle if there are 3 or less events
+            <Button variant="secondary" onClick={handleClick}>
+              {displayFullList ? "Show less" : "Show more"}
+            </Button>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -25,21 +25,26 @@ export default function PopularityRanking({
         <CardTitle className="text-xl">Most Popular Events</CardTitle>
       </CardHeader>
       <CardContent>
-        <ol className="mb-4 flex flex-col gap-2">
-          {(displayFullList ? topEvents : topEvents.slice(0, 3)).map(
-            (event, index: number) => (
-              <li
-                key={event.id}
-                className={`flex justify-between text-sm ${RANKING_STYLES[index] ?? "text-gray-400 md:text-base lg:text-base"}`}
-              >
-                <span className="me-4">
-                  {index + 1}. {event.name} &#91;{event.tag.toUpperCase()}&#93;
-                </span>
-                <span>{event.numAttended} attended</span>
-              </li>
-            ),
-          )}
-        </ol>
+        {
+          topEvents.length > 0 ?
+          <ol className="mb-4 flex flex-col gap-2">
+            {(displayFullList ? topEvents : topEvents.slice(0, 3)).map(
+              (event, index: number) => (
+                <li
+                  key={event.id}
+                  className={`flex justify-between text-sm ${RANKING_STYLES[index] ?? "text-gray-400 md:text-base lg:text-base"}`}
+                >
+                  <span className="me-4">
+                    {index + 1}. {event.name} &#91;{event.tag.toUpperCase()}&#93;
+                  </span>
+                  <span>{event.numAttended} attended</span>
+                </li>
+              ),
+            )}
+          </ol>
+          :
+          <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
+        }
         <div className="flex justify-center">
         {
           topEvents.length > 3 && // no need for show more toggle if there are 3 or less events

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -1,15 +1,21 @@
 import { useState } from "react";
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
+import type {
+  Semester} from "@forge/consts/knight-hacks";
 import { RANKING_STYLES } from "@forge/consts/knight-hacks";
 import { Button } from "@forge/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 
 export default function PopularityRanking({
   events,
+  semester
 }: {
   events: ReturnEvent[];
+  semester: Semester | null;
 }) {
+  if (semester) console.log(`PopularityRanking semester: ${JSON.stringify(semester)}`);
+  
   const [displayFullList, setDisplayFullList] = useState<boolean>(false);
 
   const topEvents = events

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -49,9 +49,12 @@ export default function PopularityRanking({
           )}
         </ol>
         <div className="flex justify-center">
+        {
+          topEvents.length > 3 && // no need for show more toggle if there are 3 or less events
           <Button variant="secondary" onClick={handleClick}>
             {displayFullList ? "Show less" : "Show more"}
           </Button>
+        }
         </div>
       </CardContent>
     </Card>

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -43,7 +43,7 @@ export default function PopularityRanking({
             )}
           </ol>
           :
-          <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
+          <p className="mt-10 mb-14 text-center text-slate-300">No attendance data found</p>
         }
         <div className="flex justify-center">
         {

--- a/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/PopularityRanking.tsx
@@ -14,11 +14,14 @@ export default function PopularityRanking({
   events: ReturnEvent[];
   semester: Semester | null;
 }) {
-  if (semester) console.log(`PopularityRanking semester: ${JSON.stringify(semester)}`);
-  
   const [displayFullList, setDisplayFullList] = useState<boolean>(false);
 
   const topEvents = events
+    .filter(event => {
+      if (semester)
+        return event.start_datetime > semester.startDate && event.start_datetime < semester.endDate;
+      return true; // consider all events if semester is null
+    })
     .sort((a, b) => b.numAttended - a.numAttended)
     .slice(0, 10);
 

--- a/apps/blade/src/app/admin/club/data/_components/event-data/TypePie.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/TypePie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
@@ -50,6 +50,12 @@ export default function TypePie({ events }: { events: ReturnEvent[] }) {
     [activeLevel, tagData],
   );
   const tags = useMemo(() => tagData.map((item) => item.name), [tagData]);
+
+  useEffect(() => {
+    if (!tagData.some((item) => item.name === activeLevel)) {
+      setActiveLevel(tagData[0]?.name ?? null);
+    }
+  }, [tagData, activeLevel]);
 
   // set up chart config
   const baseConfig: ChartConfig = {

--- a/apps/blade/src/app/admin/club/data/_components/event-data/TypePie.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/TypePie.tsx
@@ -6,6 +6,8 @@ import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
 import type { ChartConfig } from "@forge/ui/chart";
+import type {
+  Semester} from "@forge/consts/knight-hacks";
 import { ADMIN_PIE_CHART_COLORS } from "@forge/consts/knight-hacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 import {
@@ -22,7 +24,9 @@ import {
   SelectValue,
 } from "@forge/ui/select";
 
-export default function TypePie({ events }: { events: ReturnEvent[] }) {
+export default function TypePie({ events, semester }: { events: ReturnEvent[]; semester: Semester | null }) {
+  if (semester) console.log(`TypePie semester: ${JSON.stringify(semester)}`);
+
   const id = "pie-interactive";
 
   // get amount of each tag

--- a/apps/blade/src/app/admin/club/data/_components/event-data/TypePie.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/TypePie.tsx
@@ -6,8 +6,6 @@ import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
 import type { ChartConfig } from "@forge/ui/chart";
-import type {
-  Semester} from "@forge/consts/knight-hacks";
 import { ADMIN_PIE_CHART_COLORS } from "@forge/consts/knight-hacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
 import {
@@ -24,9 +22,7 @@ import {
   SelectValue,
 } from "@forge/ui/select";
 
-export default function TypePie({ events, semester }: { events: ReturnEvent[]; semester: Semester | null }) {
-  if (semester) console.log(`TypePie semester: ${JSON.stringify(semester)}`);
-
+export default function TypePie({ events }: { events: ReturnEvent[] }) {
   const id = "pie-interactive";
 
   // get amount of each tag

--- a/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
@@ -111,36 +111,41 @@ export function WeekdayPopularityRadar({ events }: { events: ReturnEvent[] }) {
         <CardTitle className="text-xl">Average Attendance by Weekday</CardTitle>
       </CardHeader>
       <CardContent className="pb-0">
-        <ChartContainer
-          config={chartConfig}
-          className="mx-auto aspect-square max-h-[250px]"
-        >
-          <RadarChart
-            data={weekdayAvgData}
-            margin={{
-              left: 60,
-            }}
+        {
+          weekdayAvgData.length > 0 ?
+          <ChartContainer
+            config={chartConfig}
+            className="mx-auto aspect-square max-h-[250px]"
           >
-            <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-            <PolarAngleAxis dataKey="weekday" />
-            <PolarRadiusAxis
-              tick={false}
-              axisLine={false}
-              domain={[0, maxAvgAttendees]}
-            />
-            <PolarGrid />
-            <Radar
-              dataKey="avgAttendees"
-              name="Average Attendees:"
-              fill={ADMIN_PIE_CHART_COLORS[1]}
-              fillOpacity={0.6}
-              dot={{
-                r: 4,
-                fillOpacity: 1,
+            <RadarChart
+              data={weekdayAvgData}
+              margin={{
+                left: 60,
               }}
-            />
-          </RadarChart>
-        </ChartContainer>
+            >
+              <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+              <PolarAngleAxis dataKey="weekday" />
+              <PolarRadiusAxis
+                tick={false}
+                axisLine={false}
+                domain={[0, maxAvgAttendees]}
+              />
+              <PolarGrid />
+              <Radar
+                dataKey="avgAttendees"
+                name="Average Attendees:"
+                fill={ADMIN_PIE_CHART_COLORS[1]}
+                fillOpacity={0.6}
+                dot={{
+                  r: 4,
+                  fillOpacity: 1,
+                }}
+              />
+            </RadarChart>
+          </ChartContainer>
+          :
+          <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
+        }
       </CardContent>
     </Card>
   );

--- a/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
@@ -111,8 +111,7 @@ export function WeekdayPopularityRadar({ events }: { events: ReturnEvent[] }) {
         <CardTitle className="text-xl">Average Attendance by Weekday</CardTitle>
       </CardHeader>
       <CardContent className="pb-0">
-        {
-          weekdayAvgData.length > 0 ?
+        {weekdayAvgData.length > 0 ? (
           <ChartContainer
             config={chartConfig}
             className="mx-auto aspect-square max-h-[250px]"
@@ -143,9 +142,11 @@ export function WeekdayPopularityRadar({ events }: { events: ReturnEvent[] }) {
               />
             </RadarChart>
           </ChartContainer>
-          :
-          <p className="mt-16 mb-20 text-center text-slate-300">No attendance data found</p>
-        }
+        ) : (
+          <p className="mb-20 mt-16 text-center text-slate-300">
+            No attendance data found
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
@@ -10,6 +10,8 @@ import {
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
 import type { ChartConfig } from "@forge/ui/chart";
+import type {
+  Semester} from "@forge/consts/knight-hacks";
 import {
   ADMIN_PIE_CHART_COLORS,
   WEEKDAY_ORDER,
@@ -21,7 +23,8 @@ import {
   ChartTooltipContent,
 } from "@forge/ui/chart";
 
-export function WeekdayPopularityRadar({ events }: { events: ReturnEvent[] }) {
+export function WeekdayPopularityRadar({ events, semester }: { events: ReturnEvent[]; semester: Semester | null }) {
+  if (semester) console.log(`WeekdayPopularityRadar semester: ${JSON.stringify(semester)}`);
   const chartConfig = {
     attendees: {
       label: "Average attendees",

--- a/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/event-data/WeekdayPopularityRadar.tsx
@@ -10,8 +10,6 @@ import {
 
 import type { ReturnEvent } from "@forge/db/schemas/knight-hacks";
 import type { ChartConfig } from "@forge/ui/chart";
-import type {
-  Semester} from "@forge/consts/knight-hacks";
 import {
   ADMIN_PIE_CHART_COLORS,
   WEEKDAY_ORDER,
@@ -23,8 +21,7 @@ import {
   ChartTooltipContent,
 } from "@forge/ui/chart";
 
-export function WeekdayPopularityRadar({ events, semester }: { events: ReturnEvent[]; semester: Semester | null }) {
-  if (semester) console.log(`WeekdayPopularityRadar semester: ${JSON.stringify(semester)}`);
+export function WeekdayPopularityRadar({ events }: { events: ReturnEvent[] }) {
   const chartConfig = {
     attendees: {
       label: "Average attendees",

--- a/apps/blade/src/app/admin/club/data/page.tsx
+++ b/apps/blade/src/app/admin/club/data/page.tsx
@@ -28,8 +28,8 @@ export default async function Data() {
 
   return (
     <HydrateClient>
-      <main className="hborder-2 hborder-yellow-500 container mt-6">
-        <Tabs defaultValue="members" className="hborder-2 hborder-red-400">
+      <main className="container mt-6">
+        <Tabs defaultValue="members">
           <TabsList>
             <TabsTrigger value="members">Member data</TabsTrigger>
             <TabsTrigger value="events">Event data</TabsTrigger>

--- a/apps/club/src/app/_components/landing/calendar.tsx
+++ b/apps/club/src/app/_components/landing/calendar.tsx
@@ -137,7 +137,7 @@ export default function CalendarEventsPage({
                 compact
                 renderCell={renderCell}
                 onSelect={handleSelect}
-                className="... w-full text-white"
+                className="w-full text-white ..."
                 monthDropdownProps={{
                   itemClassName:
                     "bg-[#1E293B]/50 text-white hover:bg-[#334155] cursor-pointer p-2 rounded-md transition-colors",

--- a/apps/club/src/app/_components/landing/calendar.tsx
+++ b/apps/club/src/app/_components/landing/calendar.tsx
@@ -137,7 +137,7 @@ export default function CalendarEventsPage({
                 compact
                 renderCell={renderCell}
                 onSelect={handleSelect}
-                className="w-full text-white ..."
+                className="... w-full text-white"
                 monthDropdownProps={{
                   itemClassName:
                     "bg-[#1E293B]/50 text-white hover:bg-[#334155] cursor-pointer p-2 rounded-md transition-colors",

--- a/packages/consts/src/knight-hacks.ts
+++ b/packages/consts/src/knight-hacks.ts
@@ -5394,13 +5394,16 @@ export const RANKING_STYLES: string[] = [
 
 export const SEMESTER_START_DATES = {
   spring: {
-    month: 0, day: 1, // first day of January
+    month: 0,
+    day: 1, // first day of January
   },
   summer: {
-    month: 4, day: 1, // first day of May
+    month: 4,
+    day: 1, // first day of May
   },
   fall: {
-    month: 7, day: 15, // middle of August
+    month: 7,
+    day: 15, // middle of August
   },
 } as const;
 
@@ -5410,7 +5413,7 @@ export const ALL_DATES_RANGE_UNIX = {
 } as const;
 
 export interface Semester {
-  name: string,
-  startDate: Date,
-  endDate: Date,
-};
+  name: string;
+  startDate: Date;
+  endDate: Date;
+}

--- a/packages/consts/src/knight-hacks.ts
+++ b/packages/consts/src/knight-hacks.ts
@@ -5416,4 +5416,4 @@ export interface Semester {
   name: string;
   startDate: Date;
   endDate: Date;
-}
+};

--- a/packages/consts/src/knight-hacks.ts
+++ b/packages/consts/src/knight-hacks.ts
@@ -5416,4 +5416,4 @@ export interface Semester {
   name: string;
   startDate: Date;
   endDate: Date;
-};
+}

--- a/packages/consts/src/knight-hacks.ts
+++ b/packages/consts/src/knight-hacks.ts
@@ -5391,3 +5391,15 @@ export const RANKING_STYLES: string[] = [
   "md:text-lg lg:text-lg font-semibold text-gray-400",
   "md:text-lg lg:text-lg font-medium text-orange-500",
 ];
+
+export const SEMESTER_START_DATES = {
+  spring: {
+    month: 0, day: 1, // first day of January
+  },
+  summer: {
+    month: 4, day: 1, // first day of May
+  },
+  fall: {
+    month: 7, day: 15, // middle of August
+  },
+} as const;

--- a/packages/consts/src/knight-hacks.ts
+++ b/packages/consts/src/knight-hacks.ts
@@ -5403,3 +5403,14 @@ export const SEMESTER_START_DATES = {
     month: 7, day: 15, // middle of August
   },
 } as const;
+
+export const ALL_DATES_RANGE_UNIX = {
+  start: -8640000000000000,
+  end: 8640000000000000,
+} as const;
+
+export interface Semester {
+  name: string,
+  startDate: Date,
+  endDate: Date,
+};


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR.
-->
Needed a way to view event data pertaining to particular semesters.

# What

<!--
Please describe the changes made in this PR.
-->
Adds a select semester menu to the club events data dashboard (admin).

# Test Plan

<!--
Please describe how you tested the changes in this PR. 

This could include:
- How you verified the changes
- Screenshots or logs if applicable
- Any other relevant information
-->
Observed accurate chart data for all currently existing semesters:
<br>
Select dropdown:
![image](https://github.com/user-attachments/assets/2e07f25e-9c0c-4e26-98a6-968aabf1b9f1)
<br>
Differences in pie chart from all semesters vs from spring 2025:
![image](https://github.com/user-attachments/assets/5311a945-573e-4d42-85ac-330b27201ca4)
![image](https://github.com/user-attachments/assets/672ef5b8-4133-405a-8b62-e398e8d29452)
<br>
Mobile:
![image](https://github.com/user-attachments/assets/4f6b3c72-a2aa-4ba7-be30-894abe466ba0)
![image](https://github.com/user-attachments/assets/d6427cb1-8f34-4263-9fee-357ab68bbb33)

