### PR TITLE
Blade/hacker data status toggle

### DIFF
--- a/apps/blade/src/app/admin/_components/RaceOrEthnicityPie.tsx
+++ b/apps/blade/src/app/admin/_components/RaceOrEthnicityPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ChartConfig } from "@forge/ui/chart";
@@ -89,6 +89,20 @@ export default function RaceOrEthnicityPie({ people }: { people: Person[] }) {
       }
     }
   });
+
+  // update selected pie chart segment if the data changes
+  useEffect(() => {
+    const activeStillExists = raceOrEthnicityData.some(
+      (item) => item.name === activeLevel
+    );
+
+    if (raceOrEthnicityData.length <= 0) {
+      setActiveLevel(null);
+      return;
+    } else if (!activeStillExists && raceOrEthnicityData[0]) {
+      setActiveLevel(raceOrEthnicityData[0].name);
+    }
+  }, [raceOrEthnicityData, activeLevel]);
 
   return (
     <Card data-chart={id} className="flex flex-col pb-4">

--- a/apps/blade/src/app/admin/_components/RaceOrEthnicityPie.tsx
+++ b/apps/blade/src/app/admin/_components/RaceOrEthnicityPie.tsx
@@ -91,7 +91,7 @@ export default function RaceOrEthnicityPie({ people }: { people: Person[] }) {
   });
 
   return (
-    <Card data-chart={id} className="flex flex-col">
+    <Card data-chart={id} className="flex flex-col pb-4">
       <ChartStyle id={id} config={baseConfig} />
       <CardHeader className="flex-col items-start gap-4 space-y-0 pb-0">
         <div className="grid gap-1">

--- a/apps/blade/src/app/admin/_components/RaceOrEthnicityPie.tsx
+++ b/apps/blade/src/app/admin/_components/RaceOrEthnicityPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ChartConfig } from "@forge/ui/chart";
@@ -93,7 +93,7 @@ export default function RaceOrEthnicityPie({ people }: { people: Person[] }) {
   // update selected pie chart segment if the data changes
   useEffect(() => {
     const activeStillExists = raceOrEthnicityData.some(
-      (item) => item.name === activeLevel
+      (item) => item.name === activeLevel,
     );
 
     if (raceOrEthnicityData.length <= 0) {

--- a/apps/blade/src/app/admin/_components/SchoolYearPie.tsx
+++ b/apps/blade/src/app/admin/_components/SchoolYearPie.tsx
@@ -91,7 +91,7 @@ export default function SchoolYearPie({ people }: { people: Person[] }) {
   });
 
   return (
-    <Card data-chart={id} className="flex flex-col">
+    <Card data-chart={id} className="flex flex-col pb-4">
       <ChartStyle id={id} config={baseConfig} />
       <CardHeader className="flex-col items-start gap-4 space-y-0 pb-0">
         <div className="grid gap-1">

--- a/apps/blade/src/app/admin/_components/SchoolYearPie.tsx
+++ b/apps/blade/src/app/admin/_components/SchoolYearPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ChartConfig } from "@forge/ui/chart";
@@ -93,7 +93,7 @@ export default function SchoolYearPie({ people }: { people: Person[] }) {
   // update selected pie chart segment if the data changes
   useEffect(() => {
     const activeStillExists = levelOfStudyData.some(
-      (item) => item.name === activeLevel
+      (item) => item.name === activeLevel,
     );
 
     if (levelOfStudyData.length <= 0) {

--- a/apps/blade/src/app/admin/_components/SchoolYearPie.tsx
+++ b/apps/blade/src/app/admin/_components/SchoolYearPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { ChartConfig } from "@forge/ui/chart";
@@ -89,6 +89,20 @@ export default function SchoolYearPie({ people }: { people: Person[] }) {
       colorIdx++;
     }
   });
+
+  // update selected pie chart segment if the data changes
+  useEffect(() => {
+    const activeStillExists = levelOfStudyData.some(
+      (item) => item.name === activeLevel
+    );
+
+    if (levelOfStudyData.length <= 0) {
+      setActiveLevel(null);
+      return;
+    } else if (!activeStillExists && levelOfStudyData[0]) {
+      setActiveLevel(levelOfStudyData[0].name);
+    }
+  }, [levelOfStudyData, activeLevel]);
 
   return (
     <Card data-chart={id} className="flex flex-col pb-4">

--- a/apps/blade/src/app/admin/club/data/_components/member-data/GenderPie.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/member-data/GenderPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { InsertMember } from "@forge/db/schemas/knight-hacks";
@@ -70,7 +70,7 @@ export default function SchoolYearPie({
   // update selected pie chart segment if the data changes
   useEffect(() => {
     const activeStillExists = genderData.some(
-      (item) => item.name === activeLevel
+      (item) => item.name === activeLevel,
     );
 
     if (genderData.length <= 0) {

--- a/apps/blade/src/app/admin/club/data/_components/member-data/GenderPie.tsx
+++ b/apps/blade/src/app/admin/club/data/_components/member-data/GenderPie.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PieSectorDataItem } from "recharts/types/polar/Pie";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Cell, Label, Pie, PieChart, Sector } from "recharts";
 
 import type { InsertMember } from "@forge/db/schemas/knight-hacks";
@@ -66,6 +66,20 @@ export default function SchoolYearPie({
       colorIdx++;
     }
   });
+
+  // update selected pie chart segment if the data changes
+  useEffect(() => {
+    const activeStillExists = genderData.some(
+      (item) => item.name === activeLevel
+    );
+
+    if (genderData.length <= 0) {
+      setActiveLevel(null);
+      return;
+    } else if (!activeStillExists && genderData[0]) {
+      setActiveLevel(genderData[0].name);
+    }
+  }, [genderData, activeLevel]);
 
   return (
     <Card data-chart={id} className="flex flex-col">

--- a/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
+++ b/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
@@ -60,12 +60,19 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
                 ))}
               </ToggleGroup>
             </div>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-              <FirstTimeInfo hackers={filteredHackers} />
-              <AgeBarChart people={hackers} />
-              <RaceOrEthnicityPie people={hackers} />
-              <SchoolYearPie people={hackers} />
-            </div>
+        {
+          filteredHackers && filteredHackers.length > 0 ?
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
+            <FirstTimeInfo hackers={filteredHackers} />
+            <AgeBarChart people={filteredHackers} />
+            <RaceOrEthnicityPie people={filteredHackers} />
+            <SchoolYearPie people={filteredHackers} />
+          </div>
+          :
+          <h1 className="mt-20 text-center text-xl">
+            No hackers match the current filter
+          </h1>
+        }
           </div>
         )
       )}

--- a/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
+++ b/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
@@ -39,7 +39,7 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
 
 
   return (
-    <div className="mt-8">
+    <div className="mt-4 md:mt-8">
       {hackers === null ? (
         <h1 className="mt-20 text-center text-xl">
           This hackathon has no hackers!
@@ -47,9 +47,9 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
       ) : (
         hackers && (
           <div className="grid gap-4">
-            <div className="flex flex-row gap-4 p-3 w-fit">
-              <h2 className="text-lg font-semibold flex items-center">Filter by status:</h2>
-              <ToggleGroup id="status-select" className="w-fit" variant="outline" type="multiple" value={selectedStatuses} onValueChange={handleStatusChange}>
+            <div className="flex flex-col md:flex-row gap-2 md:gap-4 w-fit">
+              <h2 className="md:text-lg font-semibold flex items-center">Filter by status:</h2>
+              <ToggleGroup className="flex flex-wrap" variant="outline" type="multiple" value={selectedStatuses} onValueChange={handleStatusChange}>
                 <ToggleGroupItem value="all" aria-label="toggle-all">
                   all
                 </ToggleGroupItem>

--- a/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
+++ b/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
@@ -1,6 +1,6 @@
 import { HACKATHON_APPLICATION_STATES } from "@forge/consts/knight-hacks";
 import { ToggleGroup, ToggleGroupItem } from "@forge/ui/toggle-group";
-import { Tooltip } from "recharts";
+import { useState } from "react";
 
 import AgeBarChart from "~/app/admin/_components/AgeBarChart";
 import RaceOrEthnicityPie from "~/app/admin/_components/RaceOrEthnicityPie";
@@ -10,6 +10,33 @@ import FirstTimeInfo from "./FirstTimeInfo";
 
 export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
   const { data: hackers } = api.hacker.getHackers.useQuery(hackathonId);
+
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(["all"]);
+  const handleStatusChange = (values: string[]) => {
+    // reselect "all" if user deselects every other status filter option
+    if (values.length === 0) {
+      setSelectedStatuses(["all"]);
+      return;
+    }
+
+    // reset to only "all"
+    if (values.includes("all") && !selectedStatuses.includes("all")) {
+      setSelectedStatuses(["all"]);
+    } 
+    // if "all" was previously selected and now something else is selected
+    else if (selectedStatuses.includes("all") && values.length > 1) {
+      setSelectedStatuses(values.filter((v) => v !== "all"));
+    } 
+    // update normally
+    else {
+      setSelectedStatuses(values);
+    }
+  };
+
+  const filteredHackers = selectedStatuses.includes("all") || selectedStatuses.length === 0
+    ? hackers
+    : hackers?.filter((hacker) => selectedStatuses.includes(hacker.status));
+
 
   return (
     <div className="mt-8">
@@ -22,19 +49,19 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
           <div className="grid gap-4">
             <div className="flex flex-row gap-4 p-3 w-fit">
               <h2 className="text-lg font-semibold flex items-center">Filter by status:</h2>
-              <ToggleGroup id="status-select" className="w-fit" variant="outline" type="multiple">
+              <ToggleGroup id="status-select" className="w-fit" variant="outline" type="multiple" value={selectedStatuses} onValueChange={handleStatusChange}>
                 <ToggleGroupItem value="all" aria-label="toggle-all">
                   all
                 </ToggleGroupItem>
                 {HACKATHON_APPLICATION_STATES.map((item) => (
-                  <ToggleGroupItem value={item} aria-label={`toggle-${item}`}>
+                  <ToggleGroupItem key={item} value={item} aria-label={`toggle-${item}`}>
                     {item}
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>
             </div>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-              <FirstTimeInfo hackers={hackers} />
+              <FirstTimeInfo hackers={filteredHackers} />
               <AgeBarChart people={hackers} />
               <RaceOrEthnicityPie people={hackers} />
               <SchoolYearPie people={hackers} />

--- a/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
+++ b/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
@@ -1,6 +1,7 @@
+import { useState } from "react";
+
 import { HACKATHON_APPLICATION_STATES } from "@forge/consts/knight-hacks";
 import { ToggleGroup, ToggleGroupItem } from "@forge/ui/toggle-group";
-import { useState } from "react";
 
 import AgeBarChart from "~/app/admin/_components/AgeBarChart";
 import RaceOrEthnicityPie from "~/app/admin/_components/RaceOrEthnicityPie";
@@ -22,21 +23,21 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
     // reset to only "all"
     if (values.includes("all") && !selectedStatuses.includes("all")) {
       setSelectedStatuses(["all"]);
-    } 
+    }
     // if "all" was previously selected and now something else is selected
     else if (selectedStatuses.includes("all") && values.length > 1) {
       setSelectedStatuses(values.filter((v) => v !== "all"));
-    } 
+    }
     // update normally
     else {
       setSelectedStatuses(values);
     }
   };
 
-  const filteredHackers = selectedStatuses.includes("all") || selectedStatuses.length === 0
-    ? hackers
-    : hackers?.filter((hacker) => selectedStatuses.includes(hacker.status));
-
+  const filteredHackers =
+    selectedStatuses.includes("all") || selectedStatuses.length === 0
+      ? hackers
+      : hackers?.filter((hacker) => selectedStatuses.includes(hacker.status));
 
   return (
     <div className="mt-4 md:mt-8">
@@ -47,32 +48,43 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
       ) : (
         hackers && (
           <div className="grid gap-4">
-            <div className="flex flex-col md:flex-row gap-2 md:gap-4 w-fit">
-              <h2 className="md:text-lg font-semibold flex items-center">Filter by status:</h2>
-              <ToggleGroup className="flex flex-wrap" variant="outline" type="multiple" value={selectedStatuses} onValueChange={handleStatusChange}>
+            <div className="flex w-fit flex-col gap-2 md:flex-row md:gap-4">
+              <h2 className="flex items-center font-semibold md:text-lg">
+                Filter by status:
+              </h2>
+              <ToggleGroup
+                className="flex flex-wrap"
+                variant="outline"
+                type="multiple"
+                value={selectedStatuses}
+                onValueChange={handleStatusChange}
+              >
                 <ToggleGroupItem value="all" aria-label="toggle-all">
                   all
                 </ToggleGroupItem>
                 {HACKATHON_APPLICATION_STATES.map((item) => (
-                  <ToggleGroupItem key={item} value={item} aria-label={`toggle-${item}`}>
+                  <ToggleGroupItem
+                    key={item}
+                    value={item}
+                    aria-label={`toggle-${item}`}
+                  >
                     {item}
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>
             </div>
-        {
-          filteredHackers && filteredHackers.length > 0 ?
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-            <FirstTimeInfo hackers={filteredHackers} />
-            <AgeBarChart people={filteredHackers} />
-            <RaceOrEthnicityPie people={filteredHackers} />
-            <SchoolYearPie people={filteredHackers} />
-          </div>
-          :
-          <h1 className="mt-20 text-center text-xl">
-            No hackers match the current filter
-          </h1>
-        }
+            {filteredHackers && filteredHackers.length > 0 ? (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
+                <FirstTimeInfo hackers={filteredHackers} />
+                <AgeBarChart people={filteredHackers} />
+                <RaceOrEthnicityPie people={filteredHackers} />
+                <SchoolYearPie people={filteredHackers} />
+              </div>
+            ) : (
+              <h1 className="mt-20 text-center text-xl">
+                No hackers match the current filter
+              </h1>
+            )}
           </div>
         )
       )}

--- a/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
+++ b/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
@@ -1,3 +1,6 @@
+import { HACKATHON_APPLICATION_STATES } from "@forge/consts/knight-hacks";
+import { ToggleGroup, ToggleGroupItem } from "@forge/ui/toggle-group";
+
 import AgeBarChart from "~/app/admin/_components/AgeBarChart";
 import RaceOrEthnicityPie from "~/app/admin/_components/RaceOrEthnicityPie";
 import SchoolYearPie from "~/app/admin/_components/SchoolYearPie";
@@ -15,11 +18,23 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
         </h1>
       ) : (
         hackers && (
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-            <FirstTimeInfo hackers={hackers} />
-            <AgeBarChart people={hackers} />
-            <RaceOrEthnicityPie people={hackers} />
-            <SchoolYearPie people={hackers} />
+          <div className="grid gap-4">
+            <ToggleGroup className="w-fit" variant="outline" type="multiple">
+              <ToggleGroupItem value="all" aria-label="toggle-all">
+                all
+              </ToggleGroupItem>
+              {HACKATHON_APPLICATION_STATES.map((item) => (
+                <ToggleGroupItem value={item} aria-label={`toggle-${item}`}>
+                  {item}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
+              <FirstTimeInfo hackers={hackers} />
+              <AgeBarChart people={hackers} />
+              <RaceOrEthnicityPie people={hackers} />
+              <SchoolYearPie people={hackers} />
+            </div>
           </div>
         )
       )}

--- a/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
+++ b/apps/blade/src/app/admin/hackathon/data/_components/HackerCharts.tsx
@@ -1,5 +1,6 @@
 import { HACKATHON_APPLICATION_STATES } from "@forge/consts/knight-hacks";
 import { ToggleGroup, ToggleGroupItem } from "@forge/ui/toggle-group";
+import { Tooltip } from "recharts";
 
 import AgeBarChart from "~/app/admin/_components/AgeBarChart";
 import RaceOrEthnicityPie from "~/app/admin/_components/RaceOrEthnicityPie";
@@ -19,16 +20,19 @@ export default function HackerCharts({ hackathonId }: { hackathonId: string }) {
       ) : (
         hackers && (
           <div className="grid gap-4">
-            <ToggleGroup className="w-fit" variant="outline" type="multiple">
-              <ToggleGroupItem value="all" aria-label="toggle-all">
-                all
-              </ToggleGroupItem>
-              {HACKATHON_APPLICATION_STATES.map((item) => (
-                <ToggleGroupItem value={item} aria-label={`toggle-${item}`}>
-                  {item}
+            <div className="flex flex-row gap-4 p-3 w-fit">
+              <h2 className="text-lg font-semibold flex items-center">Filter by status:</h2>
+              <ToggleGroup id="status-select" className="w-fit" variant="outline" type="multiple">
+                <ToggleGroupItem value="all" aria-label="toggle-all">
+                  all
                 </ToggleGroupItem>
-              ))}
-            </ToggleGroup>
+                {HACKATHON_APPLICATION_STATES.map((item) => (
+                  <ToggleGroupItem value={item} aria-label={`toggle-${item}`}>
+                    {item}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
               <FirstTimeInfo hackers={hackers} />
               <AgeBarChart people={hackers} />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,8 @@
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.1",
+    "@radix-ui/react-toggle": "^1.1.9",
+    "@radix-ui/react-toggle-group": "^1.1.10",
     "class-variance-authority": "^0.7.0",
     "cmdk": "1.0.0",
     "date-fns": "^3.6.0",

--- a/packages/ui/src/toggle-group.tsx
+++ b/packages/ui/src/toggle-group.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import type {VariantProps} from "class-variance-authority";
+import { toggleVariants } from "./toggle";
+import { cn } from ".";
+
+const ToggleGroupContext = React.createContext<VariantProps>({
+  size: "default",
+  variant: "default",
+});
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef,
+  React.ComponentPropsWithoutRef & VariantProps
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+));
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef,
+  React.ComponentPropsWithoutRef & VariantProps
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+});
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };

--- a/packages/ui/src/toggle-group.tsx
+++ b/packages/ui/src/toggle-group.tsx
@@ -7,14 +7,17 @@ import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { cn } from ".";
 import { toggleVariants } from "./toggle";
 
-const ToggleGroupContext = React.createContext<VariantProps>({
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
   size: "default",
   variant: "default",
 });
 
 const ToggleGroup = React.forwardRef<
-  React.ElementRef,
-  React.ComponentPropsWithoutRef & VariantProps
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
 >(({ className, variant, size, children, ...props }, ref) => (
   <ToggleGroupPrimitive.Root
     ref={ref}
@@ -30,8 +33,9 @@ const ToggleGroup = React.forwardRef<
 ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
 
 const ToggleGroupItem = React.forwardRef<
-  React.ElementRef,
-  React.ComponentPropsWithoutRef & VariantProps
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
 >(({ className, children, variant, size, ...props }, ref) => {
   const context = React.useContext(ToggleGroupContext);
 
@@ -40,8 +44,8 @@ const ToggleGroupItem = React.forwardRef<
       ref={ref}
       className={cn(
         toggleVariants({
-          variant: context.variant || variant,
-          size: context.size || size,
+          variant: context.variant ?? variant,
+          size: context.size ?? size,
         }),
         className,
       )}

--- a/packages/ui/src/toggle-group.tsx
+++ b/packages/ui/src/toggle-group.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
-import type {VariantProps} from "class-variance-authority";
-import { toggleVariants } from "./toggle";
+
 import { cn } from ".";
+import { toggleVariants } from "./toggle";
 
 const ToggleGroupContext = React.createContext<VariantProps>({
   size: "default",

--- a/packages/ui/src/toggle.tsx
+++ b/packages/ui/src/toggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import type { VariantProps } from "class-variance-authority";
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva } from "class-variance-authority";
+import { cn } from "src/lib/utils";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+const Toggle = React.forwardRef<
+  React.ElementRef,
+  React.ComponentPropsWithoutRef & VariantProps
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle, toggleVariants };

--- a/packages/ui/src/toggle.tsx
+++ b/packages/ui/src/toggle.tsx
@@ -4,7 +4,8 @@ import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva } from "class-variance-authority";
-import { cn } from "src/lib/utils";
+
+import { cn } from ".";
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -29,8 +30,9 @@ const toggleVariants = cva(
 );
 
 const Toggle = React.forwardRef<
-  React.ElementRef,
-  React.ComponentPropsWithoutRef & VariantProps
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
 >(({ className, variant, size, ...props }, ref) => (
   <TogglePrimitive.Root
     ref={ref}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,12 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.1
         version: 1.1.2(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.9
+        version: 1.1.9(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -886,7 +892,7 @@ importers:
         version: 14.2.21
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(eslint@9.17.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.0
         version: 6.10.2(eslint@9.17.0(jiti@2.4.2))
@@ -3351,6 +3357,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.10':
+    resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.1.4':
     resolution: {integrity: sha512-pOkb2u8KgO47j/h7AylCj7dJsm69BXcjkrvTqMptFqsE2i0p8lHkfgneXKjAgPzBMivnoMyt8o4KiV4wYzDdyQ==}
     peerDependencies:
@@ -3430,6 +3449,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-toggle-group@1.1.10':
+    resolution: {integrity: sha512-kiU694Km3WFLTC75DdqgM/3Jauf3rD9wxeS9XtyWFKsBUeZA337lC+6uUazT7I1DhanZ5gyD5Stf8uf2dbQxOQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.9':
+    resolution: {integrity: sha512-ZoFkBBz9zv9GWer7wIjvdRxmh2wyc2oKWw6C6CseWd6/yq1DK/l5lJ+wnsmFwJZbBYqr02mrf8A2q/CVCuM3ZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.0.1':
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
     peerDependencies:
@@ -3441,6 +3486,15 @@ packages:
 
   '@radix-ui/react-use-callback-ref@1.1.0':
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -11527,6 +11581,23 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 19.1.2(@types/react@18.3.18)
 
+  '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 19.1.2(@types/react@18.3.18)
+
   '@radix-ui/react-select@2.1.4(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/number': 1.1.0
@@ -11622,6 +11693,32 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 19.1.2(@types/react@18.3.18)
 
+  '@radix-ui/react-toggle-group@1.1.10(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.9(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 19.1.2(@types/react@18.3.18)
+
+  '@radix-ui/react-toggle@1.1.9(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 19.1.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 19.1.2(@types/react@18.3.18)
+
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -11630,6 +11727,12 @@ snapshots:
       '@types/react': 18.3.18
 
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.18)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.18
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -14056,6 +14159,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@9.17.0(jiti@2.4.2)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.31.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
+      eslint: 9.17.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
@@ -14067,13 +14180,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.17.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
       debug: 3.2.7
-    optionalDependencies:
+      doctrine: 2.1.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint@9.17.0(jiti@2.4.2))
+      hasown: 2.0.2
+      is-core-module: 2.16.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.31.0(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.2)
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.7.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
@@ -14100,33 +14233,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.7.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.31.0(eslint@9.17.0(jiti@2.4.2)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.17.0(jiti@2.4.2)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.17.0(jiti@2.4.2))
-      hasown: 2.0.2
-      is-core-module: 2.16.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR.
-->
Wanted a way to filter hacker data charts by application status.

# What

<!--
Please describe the changes made in this PR.
-->
Added hacker status toggle group to the hackathon data dashboard. Charts only display data pertaining to hackers whose status matches the filter.

# Test Plan

<!--
Please describe how you tested the changes in this PR. 

This could include:
- How you verified the changes
- Screenshots or logs if applicable
- Any other relevant information
-->
Verified functionality with test hacker data:
![image](https://github.com/user-attachments/assets/8a024178-9c34-4fb8-b027-293f3c5d25f9)
https://github.com/user-attachments/assets/df1cbabc-6f59-412b-a145-1240c5034408
![image](https://github.com/user-attachments/assets/0c872494-13ac-4edc-bada-827a3356ec7a)