### PR TITLE
Add application email for KH8, polish pre-existing acceptance email

### DIFF
--- a/apps/blade/src/app/admin/hackathon/hackers/_components/accept-button.tsx
+++ b/apps/blade/src/app/admin/hackathon/hackers/_components/accept-button.tsx
@@ -7,7 +7,7 @@ import { Button } from "@forge/ui/button";
 import { toast } from "@forge/ui/toast";
 
 import { api } from "~/trpc/react";
-import { GemiKnightsAcceptanceEmail } from "./gemiknights-acceptance-email";
+import KH8AcceptanceEmail from "./kh8-acceptance-email";
 
 export default function AcceptButton({
   hacker,
@@ -55,7 +55,7 @@ export default function AcceptButton({
     });
 
     const html = await render(
-      <GemiKnightsAcceptanceEmail
+      <KH8AcceptanceEmail
         name={`${hacker.firstName} ${hacker.lastName}`}
       />,
     );

--- a/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-acceptance-email.tsx
+++ b/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-acceptance-email.tsx
@@ -1,0 +1,411 @@
+import {
+  Body,
+  Container,
+  Head,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface AcceptanceEmailProps {
+  name: string;
+}
+
+export const KH8AcceptanceEmail = ({ name }: AcceptanceEmailProps) => {
+  const previewText = `Congrats ${name}! Your spot at KnightHacks is secured 🎉`;
+
+  return (
+    <Html>
+      <Head/>
+      <Tailwind
+        config={{
+          theme: {
+            extend: {
+              fontFamily: {
+                sans: ["Arial"],
+              },
+            },
+          },
+        }}
+      >
+        <Body className="m-0 bg-[#ECECEC] p-0 font-sans">
+          <Preview>{previewText}</Preview>
+
+          <Container className="mx-auto max-w-[600px] p-0">
+            <Section className="my-1 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/UvC8nCh.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "50%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="z-10 mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td
+                    // @ts-expect-error td is tripping
+                    background="https://i.imgur.com/EtRmspk.png"
+                    width="700"
+                    height="200"
+                    align="left"
+                    valign="middle"
+                    style={{
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                    }}
+                  >
+                    <Text
+                      className=" ml-4 mb-4 p-[22px] text-[28px] font-bold leading-tight text-[#070708]"
+                    >
+                      <span className="text-[#4075B7]">Congrats,</span>
+                      <br/>
+                      <span className="text-[32px] font-bold text-[#C04B3D]">
+                        {name}!
+                      </span>
+                    </Text>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="p-0 text-center">
+              <Img
+                src="https://i.imgur.com/6fDiTiv.png"
+                width={600}
+                alt="KnightHacks Banner"
+                className="mt-[-50px] h-auto w-full"
+              />
+            </Section>
+
+            <Section className="my-10 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/RSl6O6h.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "100%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Text
+                      className=" text-[40px] font-normal leading-[46px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      1. CONFIRM YOUR{" "}
+                      <span className="font-bold text-[#C04B3D]">SPOT!</span>
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <Text
+                      className=" text-[20px] font-normal leading-[23px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      (Spots are filling up quickly confirm ASAP!)
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/h8b8QMm.png"
+                      width={500}
+                      height="auto"
+                      alt="Confirm Spot Graphic"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <a href={`${process.env.BLADE_URL}/dashboard`}>
+                      <Img
+                        src="https://i.imgur.com/Lxts1BH.png"
+                        width={280}
+                        height="auto"
+                        alt="Confirm Button"
+                        style={{ height: "auto" }}
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Text
+                      className=" text-[40px] font-normal leading-[46px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      2. JOIN OUR{" "}
+                      <span className="font-bold text-[#4075B7]">DISCORD!</span>
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <Text
+                      className=" text-[20px] font-normal leading-[23px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      (Required by October 23rd)
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/j67gvlZ.png"
+                      width={500}
+                      height="auto"
+                      alt="Discord Graphic"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <a href={"https://discord.com/invite/Kv5g9vf"}>
+                      <Img
+                        src="https://i.imgur.com/CuX6BqL.png"
+                        width={280}
+                        height="auto"
+                        alt="Join Discord Button"
+                        style={{ height: "auto" }}
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Text
+                      className=" text-[40px] font-normal leading-[46px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      3. SPREAD THE
+                      <br />
+                      <span className="text-5xl font-bold text-[#C04B3D]">
+                        EXCITEMENT!
+                      </span>
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/loDXiue.png"
+                      width={500}
+                      height="auto"
+                      alt="Social Media Graphic"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <a href={`${process.env.BLADE_URL}/dashboard`}>
+                      <Img
+                        src="https://i.imgur.com/UFGVeX2.png"
+                        width={280}
+                        height="auto"
+                        alt="Share Button"
+                        style={{ height: "auto" }}
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="my-10 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/zv7o3rj.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "100%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            {/* RESOURCES LINKS */}
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                    >
+                      <tr>
+                        <td align="center" style={{ paddingRight: "10px" }}>
+                          <a href="https://2025.knighthacks.org/">
+                            <Img
+                              src="https://i.imgur.com/csimGSU.png"
+                              width={240}
+                              height="auto"
+                              alt="Resource 1"
+                              style={{ height: "auto" }}
+                            />
+                          </a>
+                        </td>
+                        <td align="center">
+                          <a href={`${process.env.BLADE_URL}/guide`}>
+                            <Img
+                              src="https://i.imgur.com/QGmXqoQ.png"
+                              width={240}
+                              height="auto"
+                              alt="Resource 2"
+                              style={{ height: "auto" }}
+                            />
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/4h4rs7S.png"
+                      width={500}
+                      height="auto"
+                      alt="Footer Image"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="my-1 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/UvC8nCh.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "50%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default KH8AcceptanceEmail;

--- a/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-acceptance-email.tsx
+++ b/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-acceptance-email.tsx
@@ -72,7 +72,7 @@ export const KH8AcceptanceEmail = ({ name }: AcceptanceEmailProps) => {
                 <tr>
                   <td
                     // @ts-expect-error td is tripping
-                    background="https://i.imgur.com/EtRmspk.png"
+                    background="https://i.imgur.com/XlGEJ11.png"
                     width="700"
                     height="200"
                     align="left"
@@ -83,10 +83,11 @@ export const KH8AcceptanceEmail = ({ name }: AcceptanceEmailProps) => {
                     }}
                   >
                     <Text
-                      className=" ml-4 mb-4 p-[22px] text-[28px] font-bold leading-tight text-[#070708]"
+                      className="mb-6 p-[22px] text-[28px] font-bold leading-tight text-[#070708]"
                     >
-                      <span className="text-[#4075B7]">Congrats,</span>
+                      &nbps;<span className="text-[#4075B7]">Congrats,</span>
                       <br/>
+                      &nbps;
                       <span className="text-[32px] font-bold text-[#C04B3D]">
                         {name}!
                       </span>
@@ -98,7 +99,7 @@ export const KH8AcceptanceEmail = ({ name }: AcceptanceEmailProps) => {
 
             <Section className="p-0 text-center">
               <Img
-                src="https://i.imgur.com/6fDiTiv.png"
+                src="https://i.imgur.com/qLVlama.png"
                 width={600}
                 alt="KnightHacks Banner"
                 className="mt-[-50px] h-auto w-full"
@@ -266,27 +267,53 @@ export const KH8AcceptanceEmail = ({ name }: AcceptanceEmailProps) => {
                   </td>
                 </tr>
                 <tr>
-                  <td align="center" style={{ padding: "20px 0" }}>
+                  <td align="center" style={{ padding: "10px 0" }}>
                     <Img
                       src="https://i.imgur.com/loDXiue.png"
                       width={500}
                       height="auto"
-                      alt="Social Media Graphic"
+                      alt="Poster Graphic"
                       style={{ maxWidth: "100%", height: "auto" }}
                     />
                   </td>
                 </tr>
                 <tr>
-                  <td align="center" style={{ padding: "10px 0" }}>
-                    <a href={`${process.env.BLADE_URL}/dashboard`}>
-                      <Img
-                        src="https://i.imgur.com/UFGVeX2.png"
-                        width={280}
-                        height="auto"
-                        alt="Share Button"
-                        style={{ height: "auto" }}
-                      />
-                    </a>
+                  <td align="center" style={{ padding: "5px 0" }}>
+                    <table
+                      role="presentation"
+                      width="100%"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                    >
+                      <td align="center">
+                        <Img
+                          src="https://i.imgur.com/rlx2A55.png"
+                          width={150}
+                          height="auto"
+                          alt="Poster No Text"
+                          style={{ height: "auto" }}
+                        />
+                      </td>
+                      <td align="center" style={{ padding: "5px 0" }}>
+                        <Img
+                          src="https://i.imgur.com/5TuuXe0.png"
+                          width={150}
+                          height="auto"
+                          alt="Website Background"
+                          style={{ height: "auto" }}
+                        />
+                      </td>
+                      <td align="center" style={{ padding: "5px 0" }}>
+                        <Img
+                          src="https://i.imgur.com/6X2ux1W.png"
+                          width={150}
+                          height="auto"
+                          alt="Poster No Mascots"
+                          style={{ height: "auto" }}
+                        />
+                      </td>
+                    </table>
                   </td>
                 </tr>
               </table>

--- a/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-apply-email.tsx
+++ b/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-apply-email.tsx
@@ -15,7 +15,7 @@ interface AcceptanceEmailProps {
 }
 
 export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
-  const previewText = `${name}, thank you for applying to KnightHacks!`;
+  const previewText = `${name}, thank you for applying to KnightHacks! Here's what you need to do:`;
 
   return (
     <Html>
@@ -72,7 +72,7 @@ export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
                 <tr>
                   <td
                     // @ts-expect-error td is tripping
-                    background="https://i.imgur.com/EtRmspk.png"
+                    background="https://i.imgur.com/XlGEJ11.png"
                     width="700"
                     height="200"
                     align="left"
@@ -83,7 +83,7 @@ export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
                     }}
                   >
                     <Text
-                      className=" ml-4 mb-4 p-[22px] text-[28px] font-bold leading-tight text-[#070708]"
+                      className="ml-3 mb-6 p-[22px] text-[28px] font-bold leading-tight text-[#070708]"
                     >
                       <span className="text-[#4075B7]">Thanks for applying,</span>
                       <br/>
@@ -98,7 +98,7 @@ export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
 
             <Section className="p-0 text-center">
               <Img
-                src="https://i.imgur.com/rjujtbx.png"
+                src="https://i.imgur.com/R3VbtS9.png"
                 width={600}
                 alt="KnightHacks Banner"
                 className="mt-[-50px] h-auto w-full"
@@ -156,7 +156,7 @@ export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
                       className=" text-[20px] font-normal leading-[25px] tracking-[0.01em]"
                       style={{ margin: 0 }}
                     >
-                      Now that your application is on file, there’s nothing left for you to do. We will be processing applications [I DONT KNOW WHEN], so keep an eye on your inbox for our signal.
+                      Now that your application is on file, there’s nothing left for you to do. We will be processing applications as we get closer to the date, so keep an eye on your inbox for our signal.
                       <br/><br/>
                       Bide your time, hone your skills.
                       <br/>
@@ -246,27 +246,53 @@ export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
                   </td>
                 </tr>
                 <tr>
-                  <td align="center" style={{ padding: "20px 0" }}>
+                  <td align="center" style={{ padding: "10px 0" }}>
                     <Img
                       src="https://i.imgur.com/loDXiue.png"
                       width={500}
                       height="auto"
-                      alt="Social Media Graphic"
+                      alt="Poster Graphic"
                       style={{ maxWidth: "100%", height: "auto" }}
                     />
                   </td>
                 </tr>
                 <tr>
-                  <td align="center" style={{ padding: "10px 0" }}>
-                    <a href={`${process.env.BLADE_URL}/dashboard`}>
-                      <Img
-                        src="https://i.imgur.com/UFGVeX2.png"
-                        width={280}
-                        height="auto"
-                        alt="Share Button"
-                        style={{ height: "auto" }}
-                      />
-                    </a>
+                  <td align="center" style={{ padding: "5px 0" }}>
+                    <table
+                      role="presentation"
+                      width="100%"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                    >
+                      <td align="center">
+                        <Img
+                          src="https://i.imgur.com/rlx2A55.png"
+                          width={150}
+                          height="auto"
+                          alt="Poster No Text"
+                          style={{ height: "auto" }}
+                        />
+                      </td>
+                      <td align="center" style={{ padding: "5px 0" }}>
+                        <Img
+                          src="https://i.imgur.com/5TuuXe0.png"
+                          width={150}
+                          height="auto"
+                          alt="Website Background"
+                          style={{ height: "auto" }}
+                        />
+                      </td>
+                      <td align="center" style={{ padding: "5px 0" }}>
+                        <Img
+                          src="https://i.imgur.com/6X2ux1W.png"
+                          width={150}
+                          height="auto"
+                          alt="Poster No Mascots"
+                          style={{ height: "auto" }}
+                        />
+                      </td>
+                    </table>
                   </td>
                 </tr>
               </table>
@@ -316,24 +342,13 @@ export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
                       border={0}
                     >
                       <tr>
-                        <td align="center" style={{ paddingRight: "10px" }}>
+                        <td align="center">
                           <a href="https://2025.knighthacks.org/">
                             <Img
                               src="https://i.imgur.com/csimGSU.png"
                               width={240}
                               height="auto"
                               alt="Resource 1"
-                              style={{ height: "auto" }}
-                            />
-                          </a>
-                        </td>
-                        <td align="center">
-                          <a href={`${process.env.BLADE_URL}/guide`}>
-                            <Img
-                              src="https://i.imgur.com/QGmXqoQ.png"
-                              width={240}
-                              height="auto"
-                              alt="Resource 2"
                               style={{ height: "auto" }}
                             />
                           </a>

--- a/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-apply-email.tsx
+++ b/apps/blade/src/app/admin/hackathon/hackers/_components/kh8-apply-email.tsx
@@ -1,0 +1,391 @@
+import {
+  Body,
+  Container,
+  Head,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+interface AcceptanceEmailProps {
+  name: string;
+}
+
+export const KH8ApplyEmail = ({ name }: AcceptanceEmailProps) => {
+  const previewText = `${name}, thank you for applying to KnightHacks!`;
+
+  return (
+    <Html>
+      <Head/>
+      <Tailwind
+        config={{
+          theme: {
+            extend: {
+              fontFamily: {
+                sans: ["Arial"],
+              },
+            },
+          },
+        }}
+      >
+        <Body className="m-0 bg-[#ECECEC] p-0 font-sans">
+          <Preview>{previewText}</Preview>
+
+          <Container className="mx-auto max-w-[600px] p-0">
+            <Section className="my-1 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/UvC8nCh.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "50%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="z-10 mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td
+                    // @ts-expect-error td is tripping
+                    background="https://i.imgur.com/EtRmspk.png"
+                    width="700"
+                    height="200"
+                    align="left"
+                    valign="middle"
+                    style={{
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                    }}
+                  >
+                    <Text
+                      className=" ml-4 mb-4 p-[22px] text-[28px] font-bold leading-tight text-[#070708]"
+                    >
+                      <span className="text-[#4075B7]">Thanks for applying,</span>
+                      <br/>
+                      <span className="text-[32px] font-bold text-[#C04B3D]">
+                        {name}!
+                      </span>
+                    </Text>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="p-0 text-center">
+              <Img
+                src="https://i.imgur.com/rjujtbx.png"
+                width={600}
+                alt="KnightHacks Banner"
+                className="mt-[-50px] h-auto w-full"
+              />
+            </Section>
+
+            <Section className="my-10 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/RSl6O6h.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "100%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Text
+                      className=" text-[40px] font-normal leading-[46px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      1. WATCH YOUR{" "}
+                      <span className="font-bold text-[#C04B3D]">INBOX!</span>
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <Text
+                      className=" text-[20px] font-normal leading-[25px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      Now that your application is on file, there’s nothing left for you to do. We will be processing applications [I DONT KNOW WHEN], so keep an eye on your inbox for our signal.
+                      <br/><br/>
+                      Bide your time, hone your skills.
+                      <br/>
+                      <span className="font-bold text-[#4075B7]">T.K.</span> and <span className="font-bold text-[#C04B3D]">Lenny</span> will need all the help they can get!
+                    </Text>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Text
+                      className=" text-[40px] font-normal leading-[46px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      2. JOIN OUR{" "}
+                      <span className="font-bold text-[#4075B7]">DISCORD!</span>
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <Text
+                      className=" text-[20px] font-normal leading-[23px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      (Required by October 23rd)
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/j67gvlZ.png"
+                      width={500}
+                      height="auto"
+                      alt="Discord Graphic"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <a href={"https://discord.com/invite/Kv5g9vf"}>
+                      <Img
+                        src="https://i.imgur.com/CuX6BqL.png"
+                        width={280}
+                        height="auto"
+                        alt="Join Discord Button"
+                        style={{ height: "auto" }}
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Text
+                      className=" text-[40px] font-normal leading-[46px] tracking-[0.01em]"
+                      style={{ margin: 0 }}
+                    >
+                      3. SPREAD THE
+                      <br />
+                      <span className="text-5xl font-bold text-[#C04B3D]">
+                        EXCITEMENT!
+                      </span>
+                    </Text>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/loDXiue.png"
+                      width={500}
+                      height="auto"
+                      alt="Social Media Graphic"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <a href={`${process.env.BLADE_URL}/dashboard`}>
+                      <Img
+                        src="https://i.imgur.com/UFGVeX2.png"
+                        width={280}
+                        height="auto"
+                        alt="Share Button"
+                        style={{ height: "auto" }}
+                      />
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="my-10 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/zv7o3rj.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "100%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            {/* RESOURCES LINKS */}
+            <Section className="mx-auto w-full p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center" style={{ padding: "20px 0" }}>
+                    <table
+                      role="presentation"
+                      cellPadding={0}
+                      cellSpacing={0}
+                      border={0}
+                    >
+                      <tr>
+                        <td align="center" style={{ paddingRight: "10px" }}>
+                          <a href="https://2025.knighthacks.org/">
+                            <Img
+                              src="https://i.imgur.com/csimGSU.png"
+                              width={240}
+                              height="auto"
+                              alt="Resource 1"
+                              style={{ height: "auto" }}
+                            />
+                          </a>
+                        </td>
+                        <td align="center">
+                          <a href={`${process.env.BLADE_URL}/guide`}>
+                            <Img
+                              src="https://i.imgur.com/QGmXqoQ.png"
+                              width={240}
+                              height="auto"
+                              alt="Resource 2"
+                              style={{ height: "auto" }}
+                            />
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style={{ padding: "10px 0" }}>
+                    <Img
+                      src="https://i.imgur.com/4h4rs7S.png"
+                      width={500}
+                      height="auto"
+                      alt="Footer Image"
+                      style={{ maxWidth: "100%", height: "auto" }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+
+            <Section className="my-1 p-0">
+              <table
+                role="presentation"
+                width="100%"
+                cellPadding={0}
+                cellSpacing={0}
+                border={0}
+              >
+                <tr>
+                  <td align="center">
+                    <Img
+                      src="https://i.imgur.com/UvC8nCh.png"
+                      width={700}
+                      height="auto"
+                      alt="Divider"
+                      style={{
+                        maxWidth: "50%",
+                        height: "auto",
+                        margin: "0 auto",
+                      }}
+                    />
+                  </td>
+                </tr>
+              </table>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default KH8ApplyEmail;

--- a/apps/blade/src/app/hacker/application/_components/hacker-application-form.tsx
+++ b/apps/blade/src/app/hacker/application/_components/hacker-application-form.tsx
@@ -44,6 +44,8 @@ import { Textarea } from "@forge/ui/textarea";
 import { toast } from "@forge/ui/toast";
 
 import { api } from "~/trpc/react";
+import { render } from "@react-email/render";
+import KH8ApplyEmail from "~/app/admin/hackathon/hackers/_components/kh8-apply-email";
 
 export function HackerFormPage({
   hackathonId,
@@ -87,6 +89,8 @@ export function HackerFormPage({
       setLoading(false);
     },
   });
+
+  const sendEmail = api.email.sendEmail.useMutation()
 
   const toggleAllergy = (allergy: string) => {
     setSelectedAllergies((prev) => {
@@ -365,6 +369,19 @@ export function HackerFormPage({
               foodAllergies: values.foodAllergies,
               resumeUrl,
               hackathonName: hackathonId,
+            });
+
+            const html = await render(
+              <KH8ApplyEmail
+                name={`${values.firstName} ${values.lastName}`}
+              />,
+            );
+            
+            sendEmail.mutate({
+              from: "donotreply@knighthacks.org",
+              to: values.email,
+              subject: "KnightHacks VIII - We recieved your application!",
+              body: html,
             });
           } catch (error) {
             // eslint-disable-next-line no-console

--- a/packages/api/src/routers/email.ts
+++ b/packages/api/src/routers/email.ts
@@ -3,7 +3,7 @@ import type { GaxiosError } from "googleapis-common";
 import { z } from "zod";
 
 import { publicProcedure } from "../trpc";
-import { gmail, log } from "../utils";
+import { gmail } from "../utils";
 
 export const emailRouter = {
   sendEmail: publicProcedure
@@ -30,14 +30,7 @@ export const emailRouter = {
         });
       } catch (err: unknown) {
         const gaxiosError = err as GaxiosError;
-        if (gaxiosError.code === "409" || gaxiosError.status === 409) {
-          await log({
-            title: "SendAs Alias Already Exists",
-            message: `SendAs alias already exists for ${alias}, continuing with email send`,
-            color: "tk_blue",
-            userId: "system",
-          });
-        } else {
+        if (!(gaxiosError.code === "409" || gaxiosError.status === 409)) {
           console.error("Error creating sendAs alias:", err);
           throw new Error(
             `Failed to create sendAs alias: ${


### PR DESCRIPTION
# What

Added an application email for KH8, as well as functionality in Blade to send this email when
a hacker is created from the hackathon application form. 

I also polished the acceptance email from /transactional and added it to /blade,
and attached it in place of the GemiKnights acceptance email.
Denial still uses the GemiKnights template, but we will not need that for a few more weeks at least.

# Testing

Kept sending emails to myself by refilling out the hacker application over and over again
until I got carpel tunnel/the email looked acceptable
Sorry for blowing up the bot channel but you can at least tell it worked lol