### PR TITLE
Improve sign-up flow on the Blade dashboard

### DIFF
--- a/apps/blade/src/app/_components/option-cards.tsx
+++ b/apps/blade/src/app/_components/option-cards.tsx
@@ -1,9 +1,8 @@
 import Link from "next/link";
 import { Code, Swords } from "lucide-react";
 
-import { PERMANENT_DISCORD_INVITE } from "@forge/consts/knight-hacks";
 import { cn } from "@forge/ui";
-import { Button, buttonVariants } from "@forge/ui/button";
+import { buttonVariants } from "@forge/ui/button";
 import {
   Card,
   CardContent,
@@ -12,8 +11,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@forge/ui/card";
-
-import { api } from "~/trpc/server";
 
 export function MemberAppCard() {
   return (
@@ -55,9 +52,7 @@ export function MemberAppCard() {
   );
 }
 
-export async function HackerAppCard() {
-  const currentHackathon = await api.hackathon.getCurrentHackathon();
-
+export function HackerAppCard({ hackathonName }: { hackathonName: string }) {
   return (
     <Card className="flex flex-col px-4 hover:border-primary">
       <CardHeader className="text-center">
@@ -86,23 +81,12 @@ export async function HackerAppCard() {
         </ul>
       </CardContent>
       <CardFooter>
-        {currentHackathon ? (
-          <Link
-            href={"/hacker/application/" + currentHackathon.name}
-            className={cn(buttonVariants({ variant: "primary" }), "w-full")}
-          >
-            Register Now
-          </Link>
-        ) : (
-          <Link
-            href={PERMANENT_DISCORD_INVITE}
-            className="w-full"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button className="w-full">Contact an Organizer</Button>
-          </Link>
-        )}
+        <Link
+          href={"/hacker/application/" + hackathonName}
+          className={cn(buttonVariants({ variant: "primary" }), "w-full")}
+        >
+          Register Now
+        </Link>
       </CardFooter>
     </Card>
   );

--- a/apps/blade/src/app/_components/option-cards.tsx
+++ b/apps/blade/src/app/_components/option-cards.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@forge/ui/card";
+
 import { api } from "~/trpc/server";
 
 export function MemberAppCard() {
@@ -55,8 +56,8 @@ export function MemberAppCard() {
 }
 
 export async function HackerAppCard() {
-  const currentHackathon = await api.hackathon.getCurrentHackathon()
-  
+  const currentHackathon = await api.hackathon.getCurrentHackathon();
+
   return (
     <Card className="flex flex-col px-4 hover:border-primary">
       <CardHeader className="text-center">
@@ -85,24 +86,23 @@ export async function HackerAppCard() {
         </ul>
       </CardContent>
       <CardFooter>
-        {
-          currentHackathon ? 
-            <Link
-              href={"/hacker/application/"+currentHackathon.name}
-              className={cn(buttonVariants({ variant: "primary" }), "w-full")}
-            >
-              Register Now
-            </Link>
-            :
-            <Link
-              href={PERMANENT_DISCORD_INVITE}
-              className="w-full"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button className="w-full">Contact an Organizer</Button>
-            </Link>
-        }
+        {currentHackathon ? (
+          <Link
+            href={"/hacker/application/" + currentHackathon.name}
+            className={cn(buttonVariants({ variant: "primary" }), "w-full")}
+          >
+            Register Now
+          </Link>
+        ) : (
+          <Link
+            href={PERMANENT_DISCORD_INVITE}
+            className="w-full"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button className="w-full">Contact an Organizer</Button>
+          </Link>
+        )}
       </CardFooter>
     </Card>
   );

--- a/apps/blade/src/app/_components/option-cards.tsx
+++ b/apps/blade/src/app/_components/option-cards.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@forge/ui/card";
+import { api } from "~/trpc/server";
 
 export function MemberAppCard() {
   return (
@@ -53,7 +54,9 @@ export function MemberAppCard() {
   );
 }
 
-export function HackerAppCard() {
+export async function HackerAppCard() {
+  const currentHackathon = await api.hackathon.getCurrentHackathon()
+  
   return (
     <Card className="flex flex-col px-4 hover:border-primary">
       <CardHeader className="text-center">
@@ -82,14 +85,24 @@ export function HackerAppCard() {
         </ul>
       </CardContent>
       <CardFooter>
-        <Link
-          href={PERMANENT_DISCORD_INVITE}
-          className="w-full"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Button className="w-full">Contact an Organizer</Button>
-        </Link>
+        {
+          currentHackathon ? 
+            <Link
+              href={"/hacker/application/"+currentHackathon.name}
+              className={cn(buttonVariants({ variant: "primary" }), "w-full")}
+            >
+              Register Now
+            </Link>
+            :
+            <Link
+              href={PERMANENT_DISCORD_INVITE}
+              className="w-full"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button className="w-full">Contact an Organizer</Button>
+            </Link>
+        }
       </CardFooter>
     </Card>
   );

--- a/apps/blade/src/app/_components/user-interface.tsx
+++ b/apps/blade/src/app/_components/user-interface.tsx
@@ -11,7 +11,7 @@ export async function UserInterface() {
     api.hacker.getHacker({}),
   ]);
 
-  const currentHackathon = await api.hackathon.getCurrentHackathon()
+  const currentHackathon = await api.hackathon.getCurrentHackathon();
 
   if (member.status === "rejected" || hacker.status === "rejected") {
     return (
@@ -37,7 +37,7 @@ export async function UserInterface() {
     );
   }
 
-  if (member.value && (!currentHackathon)) {
+  if (member.value && !currentHackathon) {
     return (
       <div className="flex justify-center">
         <div className="max-w-8xl w-full">
@@ -48,36 +48,39 @@ export async function UserInterface() {
   }
 
   //if (member.value && hacker.value) {
-    return (
-      <div className="flex justify-center">
-        <Tabs defaultValue={!member.value ? "Hacker" : "Member"} className="max-w-8xl relative w-full">
-          <div className="flex justify-center pb-8">
-            <TabsList className="grid w-full max-w-4xl grid-cols-2">
-              <TabsTrigger
-                value="Member"
-                className="data-[state=active]:bg-primary data-[state=active]:text-white"
-              >
-                {`${!member.value ? "Become a " : ""}Member`}
-              </TabsTrigger>
-              <TabsTrigger
-                value="Hacker"
-                className="data-[state=active]:bg-primary data-[state=active]:text-white"
-              >
-                {currentHackathon ? currentHackathon.displayName : "Hacker"}
-              </TabsTrigger>
-            </TabsList>
-          </div>
-          <TabsContent value="Member" className="mt-4 w-full">
-            <MemberDashboard member={member.value} />
-          </TabsContent>
-          <TabsContent value="Hacker" className="mt-4 w-full">
-            <HackerDashboard hacker={hacker.value} />
-          </TabsContent>
-        </Tabs>
-      </div>
-    );
- // }
-/*
+  return (
+    <div className="flex justify-center">
+      <Tabs
+        defaultValue={!member.value ? "Hacker" : "Member"}
+        className="max-w-8xl relative w-full"
+      >
+        <div className="flex justify-center pb-8">
+          <TabsList className="grid w-full max-w-4xl grid-cols-2">
+            <TabsTrigger
+              value="Member"
+              className="data-[state=active]:bg-primary data-[state=active]:text-white"
+            >
+              {`${!member.value ? "Become a " : ""}Member`}
+            </TabsTrigger>
+            <TabsTrigger
+              value="Hacker"
+              className="data-[state=active]:bg-primary data-[state=active]:text-white"
+            >
+              {currentHackathon ? currentHackathon.displayName : "Hacker"}
+            </TabsTrigger>
+          </TabsList>
+        </div>
+        <TabsContent value="Member" className="mt-4 w-full">
+          <MemberDashboard member={member.value} />
+        </TabsContent>
+        <TabsContent value="Hacker" className="mt-4 w-full">
+          <HackerDashboard hacker={hacker.value} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+  // }
+  /*
   if (member.value) {
     return (
       <div className="flex justify-center">

--- a/apps/blade/src/app/_components/user-interface.tsx
+++ b/apps/blade/src/app/_components/user-interface.tsx
@@ -31,7 +31,9 @@ export async function UserInterface() {
         </p>
         <div className="flex flex-wrap justify-center gap-5">
           <MemberAppCard />
-          <HackerAppCard />
+          {currentHackathon && (
+            <HackerAppCard hackathonName={currentHackathon.name} />
+          )}
         </div>
       </div>
     );
@@ -47,7 +49,6 @@ export async function UserInterface() {
     );
   }
 
-  //if (member.value && hacker.value) {
   return (
     <div className="flex justify-center">
       <Tabs
@@ -79,24 +80,4 @@ export async function UserInterface() {
       </Tabs>
     </div>
   );
-  // }
-  /*
-  if (member.value) {
-    return (
-      <div className="flex justify-center">
-        <div className="max-w-8xl w-full">
-          <MemberDashboard member={member.value} />
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex justify-center">
-      <div className="max-w-8xl w-full">
-        <HackerDashboard hacker={hacker.value} />
-      </div>
-    </div>
-  );
-  */
 }

--- a/apps/blade/src/app/_components/user-interface.tsx
+++ b/apps/blade/src/app/_components/user-interface.tsx
@@ -35,23 +35,23 @@ export async function UserInterface() {
     );
   }
 
-  if (member.value && hacker.value) {
+  //if (member.value && hacker.value) {
     return (
       <div className="flex justify-center">
-        <Tabs defaultValue="Member" className="max-w-8xl relative w-full">
+        <Tabs defaultValue={!member.value ? "Hacker" : "Member"} className="max-w-8xl relative w-full">
           <div className="flex justify-center pb-8">
             <TabsList className="grid w-full max-w-4xl grid-cols-2">
               <TabsTrigger
                 value="Member"
                 className="data-[state=active]:bg-primary data-[state=active]:text-white"
               >
-                Member
+                {`${!member.value ? "Become a " : ""}Member`}
               </TabsTrigger>
               <TabsTrigger
                 value="Hacker"
                 className="data-[state=active]:bg-primary data-[state=active]:text-white"
               >
-                Hacker
+                {`${!hacker.value ? "Become a " : ""}Hacker`}
               </TabsTrigger>
             </TabsList>
           </div>
@@ -64,8 +64,8 @@ export async function UserInterface() {
         </Tabs>
       </div>
     );
-  }
-
+ // }
+/*
   if (member.value) {
     return (
       <div className="flex justify-center">
@@ -83,4 +83,5 @@ export async function UserInterface() {
       </div>
     </div>
   );
+  */
 }

--- a/apps/blade/src/app/_components/user-interface.tsx
+++ b/apps/blade/src/app/_components/user-interface.tsx
@@ -11,6 +11,8 @@ export async function UserInterface() {
     api.hacker.getHacker({}),
   ]);
 
+  const currentHackathon = await api.hackathon.getCurrentHackathon()
+
   if (member.status === "rejected" || hacker.status === "rejected") {
     return (
       <div className="mt-10 flex flex-col items-center justify-center gap-y-6 font-bold">
@@ -35,6 +37,16 @@ export async function UserInterface() {
     );
   }
 
+  if (member.value && (!currentHackathon)) {
+    return (
+      <div className="flex justify-center">
+        <div className="max-w-8xl w-full">
+          <MemberDashboard member={member.value} />
+        </div>
+      </div>
+    );
+  }
+
   //if (member.value && hacker.value) {
     return (
       <div className="flex justify-center">
@@ -51,7 +63,7 @@ export async function UserInterface() {
                 value="Hacker"
                 className="data-[state=active]:bg-primary data-[state=active]:text-white"
               >
-                {`${!hacker.value ? "Become a " : ""}Hacker`}
+                {currentHackathon ? currentHackathon.displayName : "Hacker"}
               </TabsTrigger>
             </TabsList>
           </div>

--- a/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import type { api as serverCall } from "~/trpc/server";
 import { api } from "~/trpc/server";
 import { HackerData } from "./hacker-data";
 import { HackerResumeButton } from "./hacker-resume-button";
 import { PastHackathonButton } from "./past-hackathons";
+import { HackerAppCard } from "~/app/_components/option-cards";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@forge/ui/card";
+import { buttonVariants } from "@forge/ui/button";
+import { cn } from "@forge/ui";
 
 export const metadata: Metadata = {
   title: "Hacker Dashboard",
@@ -20,6 +25,50 @@ export default async function HackerDashboard({
     api.resume.getResume(),
     api.hackathon.getPastHackathons(),
   ]);
+
+  const currentHackathon = await api.hackathon.getCurrentHackathon()
+
+  if(!hacker)
+  {
+    return <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
+            <p className="w-full max-w-xl text-2xl text-center">
+              Register for KnightHacks today!
+            </p>
+            <div className="flex flex-wrap justify-center gap-5">
+              <HackerAppCard />
+              <div className="flex flex-col gap-2">
+              {
+                currentHackathon ?
+                  <>
+                  <div className="pb-1 mb-2 border-b-2 border-primary w-fit">Current Hackathon</div>
+                  <Card className="mb-8">
+                    <CardHeader>
+                      <CardTitle>{currentHackathon.displayName}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                    {
+                      currentHackathon.applicationDeadline.getTime() > Date.now() ?
+                      <>
+                      <div className="font-normal text-lg text-muted-foreground pb-2 text-left w-[345px]">{currentHackathon.startDate.toLocaleDateString() + " - " +currentHackathon.endDate.toLocaleDateString()}</div>
+                      <Link
+                        href={"/hacker/application/"+currentHackathon.name}
+                        className={cn(buttonVariants({ variant: "primary" }), "w-full")}
+                      >
+                        Register Now
+                      </Link>
+                      </>
+                      :
+                      <div/>
+                    }
+                    </CardContent>
+                  </Card>
+                  </>
+                : <div/>
+              }
+              </div>
+            </div>
+          </div>
+  }
 
   return (
     <>

--- a/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 import type { api as serverCall } from "~/trpc/server";
+import { HackerAppCard } from "~/app/_components/option-cards";
 import { api } from "~/trpc/server";
 import { HackerData } from "./hacker-data";
 import { HackerResumeButton } from "./hacker-resume-button";
 import { PastHackathonButton } from "./past-hackathons";
-import { HackerAppCard } from "~/app/_components/option-cards";
 
 export const metadata: Metadata = {
   title: "Hacker Dashboard",
@@ -22,16 +22,17 @@ export default async function HackerDashboard({
     api.hackathon.getPastHackathons(),
   ]);
 
-  if(!hacker) {
-    return(
-    <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
-      <p className="w-full max-w-xl text-2xl text-center">
-        Register for KnightHacks today!
-      </p>
-      <div className="flex flex-wrap justify-center gap-5">
-        <HackerAppCard />
+  if (!hacker) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-y-6 text-xl font-semibold">
+        <p className="w-full max-w-xl text-center text-2xl">
+          Register for KnightHacks today!
+        </p>
+        <div className="flex flex-wrap justify-center gap-5">
+          <HackerAppCard />
+        </div>
       </div>
-    </div>)
+    );
   }
 
   return (

--- a/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
@@ -22,6 +22,8 @@ export default async function HackerDashboard({
     api.hackathon.getPastHackathons(),
   ]);
 
+  const currentHackathon = await api.hackathon.getCurrentHackathon();
+
   if (!hacker) {
     return (
       <div className="flex flex-col items-center justify-center gap-y-6 text-xl font-semibold">
@@ -29,7 +31,12 @@ export default async function HackerDashboard({
           Register for KnightHacks today!
         </p>
         <div className="flex flex-wrap justify-center gap-5">
-          <HackerAppCard />
+          {
+            //if there is no current hackathon then this page is never rendered anyway
+            currentHackathon && (
+              <HackerAppCard hackathonName={currentHackathon.name} />
+            )
+          }
         </div>
       </div>
     );

--- a/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/hacker-dashboard/hacker-dashboard.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 
 import type { api as serverCall } from "~/trpc/server";
 import { api } from "~/trpc/server";
@@ -7,9 +6,6 @@ import { HackerData } from "./hacker-data";
 import { HackerResumeButton } from "./hacker-resume-button";
 import { PastHackathonButton } from "./past-hackathons";
 import { HackerAppCard } from "~/app/_components/option-cards";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@forge/ui/card";
-import { buttonVariants } from "@forge/ui/button";
-import { cn } from "@forge/ui";
 
 export const metadata: Metadata = {
   title: "Hacker Dashboard",
@@ -26,48 +22,16 @@ export default async function HackerDashboard({
     api.hackathon.getPastHackathons(),
   ]);
 
-  const currentHackathon = await api.hackathon.getCurrentHackathon()
-
-  if(!hacker)
-  {
-    return <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
-            <p className="w-full max-w-xl text-2xl text-center">
-              Register for KnightHacks today!
-            </p>
-            <div className="flex flex-wrap justify-center gap-5">
-              <HackerAppCard />
-              <div className="flex flex-col gap-2">
-              {
-                currentHackathon ?
-                  <>
-                  <div className="pb-1 mb-2 border-b-2 border-primary w-fit">Current Hackathon</div>
-                  <Card className="mb-8">
-                    <CardHeader>
-                      <CardTitle>{currentHackathon.displayName}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                    {
-                      currentHackathon.applicationDeadline.getTime() > Date.now() ?
-                      <>
-                      <div className="font-normal text-lg text-muted-foreground pb-2 text-left w-[345px]">{currentHackathon.startDate.toLocaleDateString() + " - " +currentHackathon.endDate.toLocaleDateString()}</div>
-                      <Link
-                        href={"/hacker/application/"+currentHackathon.name}
-                        className={cn(buttonVariants({ variant: "primary" }), "w-full")}
-                      >
-                        Register Now
-                      </Link>
-                      </>
-                      :
-                      <div/>
-                    }
-                    </CardContent>
-                  </Card>
-                  </>
-                : <div/>
-              }
-              </div>
-            </div>
-          </div>
+  if(!hacker) {
+    return(
+    <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
+      <p className="w-full max-w-xl text-2xl text-center">
+        Register for KnightHacks today!
+      </p>
+      <div className="flex flex-wrap justify-center gap-5">
+        <HackerAppCard />
+      </div>
+    </div>)
   }
 
   return (

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
 
 import type { api as serverCall } from "~/trpc/server";
 import { api } from "~/trpc/server";

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -38,7 +38,6 @@ export default async function MemberDashboard({
         </div>
       </div>
     );
-    //redirect("/member/application");
   }
 
   const [events, dues] = await Promise.allSettled([

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -8,6 +8,7 @@ import { EventShowcase } from "./event/event-showcase";
 import { MemberInfo } from "./info";
 import { Payment } from "./payment/payment-dues";
 import { Points } from "./points";
+import { MemberAppCard } from "~/app/_components/option-cards";
 
 export const metadata: Metadata = {
   title: "Member Dashboard",
@@ -20,7 +21,19 @@ export default async function MemberDashboard({
   member: Awaited<ReturnType<(typeof serverCall.member)["getMember"]>>;
 }) {
   if (!member) {
-    redirect("/member/application");
+    return(
+      <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
+        <p className="w-full max-w-xl text-center">
+          Are you a UCF student?<br/><br/>
+          Are you passionate about the world of tech and want to take your skills to the next level?<br/><br/>
+          Sign up to become a KnightHacks member today!
+        </p>
+        <div className="flex flex-wrap justify-center gap-5">
+          <MemberAppCard />
+        </div>
+      </div>
+    )
+    //redirect("/member/application");
   }
 
   const [events, dues] = await Promise.allSettled([

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 
 import type { api as serverCall } from "~/trpc/server";
+import { MemberAppCard } from "~/app/_components/option-cards";
 import { api } from "~/trpc/server";
 import { EventNumber } from "./event/event-number";
 import { EventShowcase } from "./event/event-showcase";
 import { MemberInfo } from "./info";
 import { Payment } from "./payment/payment-dues";
 import { Points } from "./points";
-import { MemberAppCard } from "~/app/_components/option-cards";
 
 export const metadata: Metadata = {
   title: "Member Dashboard",
@@ -20,15 +20,16 @@ export default async function MemberDashboard({
   member: Awaited<ReturnType<(typeof serverCall.member)["getMember"]>>;
 }) {
   if (!member) {
-    return(
-      <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
+    return (
+      <div className="flex flex-col items-center justify-center gap-y-6 text-xl font-semibold">
         <p className="w-full max-w-xl text-center">
           <div className="font-normal">
             Are you a UCF student?
-            <br className="mb-2"/>
-            Are you passionate about the world of tech and want to take your skills to the next level?
-            <br/>
-            <br/>
+            <br className="mb-2" />
+            Are you passionate about the world of tech and want to take your
+            skills to the next level?
+            <br />
+            <br />
           </div>
           Sign up to become a KnightHacks member today!
         </p>
@@ -36,7 +37,7 @@ export default async function MemberDashboard({
           <MemberAppCard />
         </div>
       </div>
-    )
+    );
     //redirect("/member/application");
   }
 

--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -23,8 +23,13 @@ export default async function MemberDashboard({
     return(
       <div className="flex flex-col items-center justify-center gap-y-6 font-semibold text-xl">
         <p className="w-full max-w-xl text-center">
-          Are you a UCF student?<br/><br/>
-          Are you passionate about the world of tech and want to take your skills to the next level?<br/><br/>
+          <div className="font-normal">
+            Are you a UCF student?
+            <br className="mb-2"/>
+            Are you passionate about the world of tech and want to take your skills to the next level?
+            <br/>
+            <br/>
+          </div>
           Sign up to become a KnightHacks member today!
         </p>
         <div className="flex flex-wrap justify-center gap-5">

--- a/apps/blade/src/app/settings/hacker-profile/hacker-profile-form.tsx
+++ b/apps/blade/src/app/settings/hacker-profile/hacker-profile-form.tsx
@@ -48,8 +48,12 @@ import { HackerAppCard } from "../../_components/option-cards";
 
 export function HackerProfileForm({
   data,
+  hackathon,
 }: {
   data: Awaited<ReturnType<(typeof serverCaller.hacker)["getHacker"]>>;
+  hackathon: Awaited<
+    ReturnType<(typeof serverCaller.hackathon)["getCurrentHackathon"]>
+  >;
 }) {
   const [loading, setLoading] = useState(false);
   const utils = api.useUtils();
@@ -278,7 +282,7 @@ export function HackerProfileForm({
   if (!hacker) {
     return (
       <div className="flex items-center justify-center">
-        <HackerAppCard />
+        <HackerAppCard hackathonName={hackathon?.name || ""} />
       </div>
     );
   }

--- a/apps/blade/src/app/settings/hacker-profile/page.tsx
+++ b/apps/blade/src/app/settings/hacker-profile/page.tsx
@@ -17,6 +17,7 @@ export default async function SettingsProfilePage() {
   }
 
   const hackerData = await api.hacker.getHacker({});
+  const currentHackathon = await api.hackathon.getCurrentHackathon();
 
   if (!hackerData) {
     return (
@@ -64,7 +65,7 @@ export default async function SettingsProfilePage() {
             </p>
           </div>
           <Separator />
-          <HackerProfileForm data={hackerData} />
+          <HackerProfileForm data={hackerData} hackathon={currentHackathon} />
         </div>
       </HydrateClient>
     </div>

--- a/packages/api/src/routers/hackathon.ts
+++ b/packages/api/src/routers/hackathon.ts
@@ -2,7 +2,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { asc, count, desc, eq, getTableColumns, gte } from "@forge/db";
+import { count, desc, eq, getTableColumns } from "@forge/db";
 import { db } from "@forge/db/client";
 import {
   Hackathon,
@@ -21,8 +21,8 @@ export const hackathonRouter = {
   getCurrentHackathon: publicProcedure.query(async () => {
     // Find first hackathon that hasnt ended yet
     return await db.query.Hackathon.findFirst({
-      orderBy: asc(Hackathon.endDate),
-      where: gte(Hackathon.endDate, new Date())
+      orderBy: (t, { asc }) => asc(t.endDate),
+      where: (t, { and, gte, lte }) => and(gte(t.endDate, new Date()), lte(t.applicationOpen, new Date()))
     })
   }),
 

--- a/packages/api/src/routers/hackathon.ts
+++ b/packages/api/src/routers/hackathon.ts
@@ -2,7 +2,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { count, desc, eq, getTableColumns } from "@forge/db";
+import { asc, count, desc, eq, getTableColumns, gt } from "@forge/db";
 import { db } from "@forge/db/client";
 import {
   Hackathon,
@@ -16,6 +16,14 @@ import { log } from "../utils";
 export const hackathonRouter = {
   getHackathons: publicProcedure.query(async () => {
     return await db.query.Hackathon.findMany();
+  }),
+
+  getCurrentHackathon: publicProcedure.query(async () => {
+    //Find next start date
+    return await db.query.Hackathon.findFirst({
+      orderBy: asc(Hackathon.startDate),
+      where: gt(Hackathon.startDate, new Date())
+    })
   }),
 
   getPreviousHacker: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/api/src/routers/hackathon.ts
+++ b/packages/api/src/routers/hackathon.ts
@@ -2,7 +2,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { asc, count, desc, eq, getTableColumns, gt } from "@forge/db";
+import { asc, count, desc, eq, getTableColumns, gte } from "@forge/db";
 import { db } from "@forge/db/client";
 import {
   Hackathon,
@@ -19,10 +19,10 @@ export const hackathonRouter = {
   }),
 
   getCurrentHackathon: publicProcedure.query(async () => {
-    //Find next start date
+    // Find first hackathon that hasnt ended yet
     return await db.query.Hackathon.findFirst({
-      orderBy: asc(Hackathon.startDate),
-      where: gt(Hackathon.startDate, new Date())
+      orderBy: asc(Hackathon.endDate),
+      where: gte(Hackathon.endDate, new Date())
     })
   }),
 

--- a/packages/api/src/routers/hackathon.ts
+++ b/packages/api/src/routers/hackathon.ts
@@ -22,8 +22,9 @@ export const hackathonRouter = {
     // Find first hackathon that hasnt ended yet
     return await db.query.Hackathon.findFirst({
       orderBy: (t, { asc }) => asc(t.endDate),
-      where: (t, { and, gte, lte }) => and(gte(t.endDate, new Date()), lte(t.applicationOpen, new Date()))
-    })
+      where: (t, { and, gte, lte }) =>
+        and(gte(t.endDate, new Date()), lte(t.applicationOpen, new Date())),
+    });
   }),
 
   getPreviousHacker: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/api/src/routers/qr.ts
+++ b/packages/api/src/routers/qr.ts
@@ -1,6 +1,10 @@
 import type { TRPCRouterRecord } from "@trpc/server";
+import QRCode from "qrcode";
 
-import { BUCKET_NAME } from "@forge/consts/knight-hacks";
+import {
+  BUCKET_NAME,
+  KNIGHTHACKS_S3_BUCKET_REGION,
+} from "@forge/consts/knight-hacks";
 
 import { minioClient } from "../minio/minio-client";
 import { protectedProcedure } from "../trpc";
@@ -11,11 +15,33 @@ export const qrRouter = {
     const objectName = `qr-code-${userId}.png`;
 
     try {
+      try {
+        await minioClient.statObject(BUCKET_NAME, objectName);
+      } catch {
+        const bucketExists = await minioClient.bucketExists(BUCKET_NAME);
+        if (!bucketExists) {
+          await minioClient.makeBucket(
+            BUCKET_NAME,
+            KNIGHTHACKS_S3_BUCKET_REGION,
+          );
+        }
+        const qrData = `user:${userId}`;
+        const qrBuffer = await QRCode.toBuffer(qrData, { type: "png" });
+        await minioClient.putObject(
+          BUCKET_NAME,
+          objectName,
+          qrBuffer,
+          qrBuffer.length,
+          { "Content-Type": "image/png" },
+        );
+      }
+
       const qrCodeUrl = await minioClient.presignedGetObject(
         BUCKET_NAME,
         objectName,
         60 * 60 * 24,
       );
+
       return { qrCodeUrl };
     } catch {
       throw new Error("Failed to fetch the QR code URL.");


### PR DESCRIPTION
# Why

Sign-up flow is bad on Blade when you have a Hacker account but no Member account, or vice versa.
If you are only a hacker, the option to sign up as a member is completely hidden from the dashboard,
and must be manually typed as a URL.

Less severely, if you are only a member, there is no indication of where to access the hackathon sign-up anywhere.

# What

Altered the dashboard to show both Hacker and Member tabs if one of any account exists.
Added a fallback for both dashboards to present a registration advert if either account type isn't found.
Added a tRPC route to fetch the current hackathon, by whatever one has the soonest end date that hasn't been passed yet where applications are open.
The "Join the Hackathon" card has a registration link if there is a current hackathon, and defaults to the old "Contact an Organizer" if none exists yet.
Hacker tab is renamed to the display name for whatever the current hackathon is, with "Hacker" as a fallback

**Additional**
Generate a QR code if a user's code is null

# Test Plan

Checked the following cases to ensure UI functionality:
- No account of either type
- Member, but not hacker
- Hacker, but not member
- Both Member and Hacker
- No hackathons in DB
- Hackathon is present
- Hackathon is present, but applications haven't opened yet
- Hackathon has already ended