### PR TITLE
Small clean up of the scanner, many events would pop up on the drop d…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
         version: 1.9.3
       geist:
         specifier: ^1.3.1
-        version: 1.3.1(next@14.2.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.3.1(next@14.2.28(@babel/core@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       google-auth-library:
         specifier: ^9.15.0
         version: 9.15.0
@@ -246,7 +246,7 @@ importers:
         version: 8.0.3
       next:
         specifier: ^14.2.26
-        version: 14.2.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.28(@babel/core@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -669,6 +669,9 @@ importers:
       discord-api-types:
         specifier: ^0.37.113
         version: 0.37.113
+      marked:
+        specifier: ^16.2.1
+        version: 16.2.1
       minio:
         specifier: ^8.0.3
         version: 8.0.3
@@ -697,6 +700,9 @@ importers:
       '@forge/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
+      '@types/marked':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@types/pg':
         specifier: ^8.11.10
         version: 8.11.10
@@ -4497,6 +4503,10 @@ packages:
   '@types/lodash@4.17.14':
     resolution: {integrity: sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==}
 
+  '@types/marked@6.0.0':
+    resolution: {integrity: sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==}
+    deprecated: This is a stub types definition. marked provides its own type definitions, so you do not need this installed.
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -6671,6 +6681,11 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  marked@16.2.1:
+    resolution: {integrity: sha512-r3UrXED9lMlHF97jJByry90cwrZBBvZmjG1L68oYfuPMW+uDTnuMbyJDymCWwbTE+f+3LhpNDKfpR3a3saFyjA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marked@7.0.4:
     resolution: {integrity: sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==}
@@ -12561,6 +12576,10 @@ snapshots:
 
   '@types/lodash@4.17.14': {}
 
+  '@types/marked@6.0.0':
+    dependencies:
+      marked: 16.2.1
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -14326,10 +14345,6 @@ snapshots:
     dependencies:
       next: 14.2.28(@babel/core@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  geist@1.3.1(next@14.2.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
-    dependencies:
-      next: 14.2.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -15124,6 +15139,8 @@ snapshots:
 
   make-error@1.3.6: {}
 
+  marked@16.2.1: {}
+
   marked@7.0.4: {}
 
   math-intrinsics@1.1.0: {}
@@ -15492,31 +15509,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.1(@babel/core@7.26.7)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.28
-      '@next/swc-darwin-x64': 14.2.28
-      '@next/swc-linux-arm64-gnu': 14.2.28
-      '@next/swc-linux-arm64-musl': 14.2.28
-      '@next/swc-linux-x64-gnu': 14.2.28
-      '@next/swc-linux-x64-musl': 14.2.28
-      '@next/swc-win32-arm64-msvc': 14.2.28
-      '@next/swc-win32-ia32-msvc': 14.2.28
-      '@next/swc-win32-x64-msvc': 14.2.28
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@14.2.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 14.2.28
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001714
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.28
       '@next/swc-darwin-x64': 14.2.28
@@ -16807,11 +16799,6 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@babel/core': 7.26.7
-
-  styled-jsx@5.1.1(react@18.3.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.3.1
 
   styled-jsx@5.1.6(react@19.1.0):
     dependencies:


### PR DESCRIPTION
# Why

The admin events dashboard was showing both current and previous events in a single table, creating visual clutter and making it harder for admins to focus on relevant upcoming events. Additionally, when checking people into events using the scanner, admins had to scroll through all events (both current and previous) to find the right one, which was inefficient and could lead to errors.

# What

- **EventsTable Component**: Removed the previous events section from the main events dashboard table, keeping only upcoming events visible to reduce clutter
- **ScannerPopUp Component**: Added a tabbed interface to separate current and previous events in the scanner popup:
  - "Upcoming Events" tab (default) - shows current/future events for easy check-ins
  - "Previous Events" tab - shows past events for historical check-ins when needed
- **Improved UX**: The main dashboard now focuses on relevant upcoming events, while the scanner provides organized access to both current and previous events only where needed for check-ins

# Test Plan

- **Main Dashboard**: Verified that only upcoming events are displayed in the events table, with the footer showing "Upcoming Events Attendance"
- **Scanner Functionality**: 
  - Confirmed the tabbed interface works correctly with "Upcoming Events" as the default tab
  - Tested that both current and previous events are accessible in their respective tabs
  - Verified that QR scanning and event selection functionality remains unchanged
  - Ensured that the event selection dropdown populates correctly in both tabs
- **Code Quality**: 
  - No linting errors introduced
  - TypeScript compilation successful
  - Maintained all existing functionality while improving organization

The changes successfully reduce clutter on the main dashboard while keeping previous events accessible only in the scanner where they're needed for check-ins.



<img width="394" height="686" alt="{2F5775C9-8D65-442D-A31A-B268FAE03EF9}" src="https://github.com/user-attachments/assets/1746878d-ed8d-45a1-a57c-2e52d175944d" />
<img width="389" height="726" alt="{38DA8E44-2ABD-4482-B006-8E857352F5C8}" src="https://github.com/user-attachments/assets/f28566ad-bc41-4237-b1d5-bed11a1f436a" />
<img width="393" height="725" alt="{FB9B66AD-4D66-4048-A323-37F025E690A5}" src="https://github.com/user-attachments/assets/cb984673-2215-49d5-b897-eadefb92af7d" />
<img width="1651" height="1038" alt="{BAD24DD9-9A93-4C2E-B8A0-6EC845B6F7AB}" src="https://github.com/user-attachments/assets/a9b8ca3e-c0d5-410c-a9fc-085aa4e4da24" />
<img width="1631" height="1027" alt="{9BF876D5-5646-4CDF-A1B5-181B20109E0C}" src="https://github.com/user-attachments/assets/a0327c62-e65c-4a2c-b457-1b7f3c282a77" />
