### PR TITLE
Added a content-length check to base API to prevent DoS attacks

### DIFF
--- a/apps/blade/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/blade/src/app/api/trpc/[trpc]/route.ts
@@ -23,6 +23,32 @@ export const OPTIONS = () => {
 };
 
 const handler = auth(async (req) => {
+  const contentLength = req.headers.get("content-length");
+  const maxSize = 4_194_304; // 4MB in bytes
+
+  if (contentLength && parseInt(contentLength) > maxSize) {
+    const response = new Response(
+      JSON.stringify({
+        error: {
+          message: `Request too large: ${(parseInt(contentLength) / 1_000_000).toFixed(2)}MB (max: ${(maxSize / 1_000_000).toFixed(2)}MB)`,
+          code: -32000,
+          data: {
+            code: "PAYLOAD_TOO_LARGE",
+            httpStatus: 413,
+          },
+        },
+      }),
+      {
+        status: 413,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    setCorsHeaders(response);
+    return response;
+  }
+
   const response = await fetchRequestHandler({
     endpoint: "/api/trpc",
     router: appRouter,
@@ -37,7 +63,6 @@ const handler = auth(async (req) => {
       console.error(`>>> tRPC Error on '${path}'`, error);
     },
   });
-
   setCorsHeaders(response);
   return response;
 });


### PR DESCRIPTION
# Why

Blade was vulnerable to DoS and in general large request attacks.

# What

Added content-length check at base API to early return bad requests.

# Test Plan

Tested 1 byte - 4Mb limits with different payload sizes, ensured it early returned in the right placed and prevented large payload attacks.
