### PR TITLE
Allow Hackers to view Hackathon Dashboard during the Hackathon

### DIFF
--- a/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
+++ b/apps/blade/src/app/dashboard/_components/member-dashboard/member-dashboard.tsx
@@ -22,7 +22,7 @@ export default async function MemberDashboard({
   if (!member) {
     return (
       <div className="flex flex-col items-center justify-center gap-y-6 text-xl font-semibold">
-        <p className="w-full max-w-xl text-center">
+        <div className="w-full max-w-xl text-center">
           <div className="font-normal">
             Are you a UCF student?
             <br className="mb-2" />
@@ -32,7 +32,7 @@ export default async function MemberDashboard({
             <br />
           </div>
           Sign up to become a KnightHacks member today!
-        </p>
+        </div>
         <div className="flex flex-wrap justify-center gap-5">
           <MemberAppCard />
         </div>

--- a/packages/api/src/routers/hacker.ts
+++ b/packages/api/src/routers/hacker.ts
@@ -56,7 +56,7 @@ export const hackerRouter = {
         // If not provided, grab a FUTURE hackathon with a start date CLOSEST to now
         const now = new Date();
         const futureHackathons = await db.query.Hackathon.findMany({
-          where: (t, { gt }) => gt(t.startDate, now),
+          where: (t, { gt }) => gt(t.endDate, now),
           orderBy: (t, { asc }) => [asc(t.startDate)],
           limit: 1,
         });


### PR DESCRIPTION
# Why

Hackers were unable to view their Hackathon Dashboard due to a filtering bug

# What

Changed getHackers by future "endDates" not "startDates", because previously, filtering by startDates would return null for Hackers who have already started the Hackathon

# Test Plan

**Scenario:** Hacker is Checked-In in between the Start Date and End Date

Before:
<img width="1096" height="552" alt="start date - A" src="https://github.com/user-attachments/assets/7b0cfbca-e15d-4561-a251-4370a0da112a" />

After:
<img width="1466" height="553" alt="start date - B" src="https://github.com/user-attachments/assets/d88d891e-2117-4813-ba91-5a7e1eb08b2d" />


