### PR TITLE
Last minute changes before KH8 launch

### DIFF
--- a/apps/blade/src/app/admin/club/events/page.tsx
+++ b/apps/blade/src/app/admin/club/events/page.tsx
@@ -35,7 +35,7 @@ export default async function Events() {
             <h1 className="pb-4 text-center text-3xl font-extrabold tracking-tight sm:text-5xl">
               Club Events Dashboard
             </h1>
-            <div className="mb-2 flex flex-col sm:flex-row justify-center gap-2">
+            <div className="mb-2 flex flex-col justify-center gap-2 sm:flex-row">
               <ScannerPopUp eventType="Member" />
               <AddPoints type="Member" />
             </div>

--- a/apps/blade/src/app/admin/club/members/_components/scanner.tsx
+++ b/apps/blade/src/app/admin/club/members/_components/scanner.tsx
@@ -5,7 +5,8 @@ import { AwardIcon, WrenchIcon } from "lucide-react";
 import { QrReader } from "react-qr-reader";
 import { z } from "zod";
 
-import { HACKER_CLASSES, HackerClass } from "@forge/db/schemas/knight-hacks";
+import type { HackerClass } from "@forge/db/schemas/knight-hacks";
+import { HACKER_CLASSES } from "@forge/db/schemas/knight-hacks";
 import { Button } from "@forge/ui/button";
 import {
   Dialog,
@@ -26,9 +27,9 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@forge/ui/tabs";
 import { toast } from "@forge/ui/toast";
 
+import { getClassTeam } from "~/lib/utils";
 import { api } from "~/trpc/react";
 import ToggleButton from "../../../../admin/hackathon/hackers/_components/toggle-button";
-import { getClassTeam } from "~/lib/utils";
 
 const ScannerPopUp = ({ eventType }: { eventType: "Member" | "Hacker" }) => {
   const { data: events } = api.event.getEvents.useQuery();
@@ -77,7 +78,9 @@ const ScannerPopUp = ({ eventType }: { eventType: "Member" | "Hacker" }) => {
   const hackerEventCheckIn = api.hacker.eventCheckIn.useMutation({
     onSuccess(opts) {
       toast.success(opts.message);
-      setErrorColor(opts.messageforHackers.includes("[ERROR]") ? "text-red-500" : "");
+      setErrorColor(
+        opts.messageforHackers.includes("[ERROR]") ? "text-red-500" : "",
+      );
       setFirstName(opts.firstName);
       setLastName(opts.lastName);
       setAssignedClass(opts.class ?? "No class assigned");
@@ -314,11 +317,13 @@ const ScannerPopUp = ({ eventType }: { eventType: "Member" | "Hacker" }) => {
           <div className="fixed inset-0 z-[1000] flex w-full flex-col items-center justify-center gap-6 bg-black p-10 text-center text-3xl font-bold">
             <Button
               onClick={closePersistentDialog}
-              className="absolute text-lg font-semibold top-10 w-56"
+              className="absolute top-10 w-56 text-lg font-semibold"
             >
               CLOSE
             </Button>
-            <div className="border-b pb-2 w-56 -mb-2 text-lg font-bold text-muted-foreground">CHECKED IN</div>
+            <div className="-mb-2 w-56 border-b pb-2 text-lg font-bold text-muted-foreground">
+              CHECKED IN
+            </div>
             <div className="flex flex-col gap-1">
               <div className="text-sm text-muted-foreground">FIRST</div>
               <div>{firstName}</div>
@@ -329,14 +334,28 @@ const ScannerPopUp = ({ eventType }: { eventType: "Member" | "Hacker" }) => {
             </div>
             <div className="flex flex-col gap-1">
               <div className="text-sm text-muted-foreground">CLASS</div>
-              <div className="text-2xl" style={{color: getClassTeam(assignedClass as HackerClass).teamColor, textShadow: `0 0 10px ${getClassTeam(assignedClass as HackerClass).teamColor}, 0 0 20px ${getClassTeam(assignedClass as HackerClass).teamColor}`}}>{assignedClass}</div>
+              <div
+                className="text-2xl"
+                style={{
+                  color: getClassTeam(assignedClass as HackerClass).teamColor,
+                  textShadow: `0 0 10px ${getClassTeam(assignedClass as HackerClass).teamColor}, 0 0 20px ${getClassTeam(assignedClass as HackerClass).teamColor}`,
+                }}
+              >
+                {assignedClass}
+              </div>
             </div>
-            <div className="border-t w-56 -my-2"/>
-            {errorColor != "" ?
-              <div className={`top-10 w-56 text-base font-normal text-white p-1 bg-red-900 border-red-500 border rounded-sm whitespace-pre-line`}>{checkInMessage}</div>
-              :
-              <div className="top-10 w-56 text-base font-normal whitespace-pre-line">{checkInMessage}</div>
-            }
+            <div className="-my-2 w-56 border-t" />
+            {errorColor != "" ? (
+              <div
+                className={`top-10 w-56 whitespace-pre-line rounded-sm border border-red-500 bg-red-900 p-1 text-base font-normal text-white`}
+              >
+                {checkInMessage}
+              </div>
+            ) : (
+              <div className="top-10 w-56 whitespace-pre-line text-base font-normal">
+                {checkInMessage}
+              </div>
+            )}
           </div>
         )}
       </DialogContent>

--- a/apps/blade/src/app/admin/hackathon/events/page.tsx
+++ b/apps/blade/src/app/admin/hackathon/events/page.tsx
@@ -36,7 +36,7 @@ export default async function HackathonEvents() {
             <h1 className="pb-4 text-center text-3xl font-extrabold tracking-tight sm:text-5xl">
               Hackathon Events Dashboard
             </h1>
-            <div className="mb-2 flex flex-col sm:flex-row justify-center gap-2">
+            <div className="mb-2 flex flex-col justify-center gap-2 sm:flex-row">
               <ScannerPopUp eventType="Hacker" />
               <AddPoints type="Hacker" />
             </div>

--- a/apps/blade/src/app/dashboard/_components/hackathon-dashboard/countdown.tsx
+++ b/apps/blade/src/app/dashboard/_components/hackathon-dashboard/countdown.tsx
@@ -54,7 +54,7 @@ export default function HackingCountdown() {
           <div className="flex flex-wrap items-center justify-center gap-1.5 shadow-lg sm:gap-2 lg:gap-3">
             {/* Days */}
             <div className="flex items-center gap-1 sm:gap-2">
-              <Card className="shadow-md p-0">
+              <Card className="p-0 shadow-md">
                 <CardContent className="flex flex-col items-center justify-center p-2 sm:min-w-[90px] sm:p-3 lg:min-w-[110px] lg:p-4">
                   <div className="text-xl font-bold tabular-nums sm:text-4xl lg:text-5xl">
                     {formatNumber(timeLeft.days)}
@@ -72,7 +72,7 @@ export default function HackingCountdown() {
 
             {/* Hours */}
             <div className="flex items-center gap-1 shadow-lg sm:gap-2">
-              <Card className="shadow-md p-0">
+              <Card className="p-0 shadow-md">
                 <CardContent className="flex flex-col items-center justify-center p-2 sm:min-w-[90px] sm:p-3 lg:min-w-[110px] lg:p-4">
                   <div className="text-xl font-bold tabular-nums sm:text-4xl lg:text-5xl">
                     {formatNumber(timeLeft.hours)}
@@ -90,7 +90,7 @@ export default function HackingCountdown() {
 
             {/* Minutes */}
             <div className="flex items-center gap-1 shadow-lg sm:gap-2">
-              <Card className="shadow-md p-0">
+              <Card className="p-0 shadow-md">
                 <CardContent className="flex flex-col items-center justify-center p-2 sm:min-w-[90px] sm:p-3 lg:min-w-[110px] lg:p-4">
                   <div className="text-xl font-bold tabular-nums sm:text-4xl lg:text-5xl">
                     {formatNumber(timeLeft.minutes)}
@@ -107,7 +107,7 @@ export default function HackingCountdown() {
             </div>
 
             {/* Seconds */}
-            <Card className="shadow-lg p-0">
+            <Card className="p-0 shadow-lg">
               <CardContent className="flex flex-col items-center justify-center p-2 sm:min-w-[90px] sm:p-3 lg:min-w-[110px] lg:p-4">
                 <div className="text-xl font-bold tabular-nums sm:text-4xl lg:text-5xl">
                   {formatNumber(timeLeft.seconds)}

--- a/apps/blade/src/app/dashboard/_components/hackathon-dashboard/team-points.tsx
+++ b/apps/blade/src/app/dashboard/_components/hackathon-dashboard/team-points.tsx
@@ -54,7 +54,7 @@ export function TeamPoints({
   const monstrosityHex = "#c04b3d";
 
   return (
-    <Card className="bg-gradient-to-tr from-background/50 to-primary/5 shadow-lg backdrop-blur-sm gap-2">
+    <Card className="gap-2 bg-gradient-to-tr from-background/50 to-primary/5 shadow-lg backdrop-blur-sm">
       <CardHeader className="py-0">
         <div className="flex w-full flex-row justify-between text-sm sm:text-lg">
           <div

--- a/packages/api/src/routers/hacker.ts
+++ b/packages/api/src/routers/hacker.ts
@@ -1116,8 +1116,10 @@ export const hackerRouter = {
             .filter((c) => c.count === leastPopulatedClass)
             .map((c) => c.cls);
 
-          const pick:HackerClass = candidates[Math.floor(Math.random() * candidates.length)] ?? HACKER_CLASSES[0];
-          
+          const pick: HackerClass =
+            candidates[Math.floor(Math.random() * candidates.length)] ??
+            HACKER_CLASSES[0];
+
           await tx
             .update(HackerAttendee)
             .set({ class: pick, status: "checkedin" })
@@ -1196,7 +1198,8 @@ export const hackerRouter = {
           firstName: hacker.firstName,
           lastName: hacker.lastName,
           class: assignedClass,
-          messageforHackers: "[ERROR]\nThe hacker has already checked into this event.",
+          messageforHackers:
+            "[ERROR]\nThe hacker has already checked into this event.",
           eventName: eventTag,
         };
       await db.insert(HackerEventAttendee).values({


### PR DESCRIPTION
# Why

Pre-event check in revealed multiple UX and logic issues that we want to take care of before the event.

# What

Fixed UX for admin-side event scanner results. The toast no longer blocks the close button, and the design has been generally improved.

Fixed padding issues on hacker dashboard components which stemmed from the root shadcn card being changed.

Hackers with the VIP role on Discord are now assigned a standard hacker class, instead of a VIP class; this means they will have both class AND VIP roles in discord. This means that they can still participate in the team competition while retaining VIP benefits.
Code that checked for the VIP class for overrides has been altered to instead check for the Discord VIP role.

# Test Plan

Had Lewin swap my VIP role on and off in the testing Discord while scanning myself into both check-in and normal events.
<img width="397" height="835" alt="Screenshot 2025-10-23 234112" src="https://github.com/user-attachments/assets/4421832d-5dfb-4e09-8190-e3ee812c4907" />
<img width="400" height="844" alt="Screenshot 2025-10-23 234126" src="https://github.com/user-attachments/assets/c4b14d3e-49b0-432c-9a99-cd3400fc12fe" />

