### PR TITLE
Form Question Edit Component and Test Page

### DIFF
--- a/apps/blade/src/app/admin/forms/test-editor/page.tsx
+++ b/apps/blade/src/app/admin/forms/test-editor/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+// Replaced uuid import with native crypto.randomUUID for simplicity and to avoid adding dependencies
+// import { v4 as uuidv4 } from "uuid";
+const uuidv4 = () => crypto.randomUUID();
+
+import { QuestionEditCard } from "~/components/admin/forms/question-edit-card";
+import type { FormQuestion } from "~/lib/types/form";
+
+export default function TestEditorPage() {
+    const [question, setQuestion] = useState<FormQuestion>({
+        id: uuidv4(),
+        title: "Untitled Question",
+        type: "multiple_choice",
+        required: false,
+        options: [
+            { id: uuidv4(), value: "Option 1", isOther: false },
+        ],
+    });
+
+    const handleUpdate = (updatedQuestion: FormQuestion) => {
+        console.log("Updated Question:", updatedQuestion);
+        setQuestion(updatedQuestion);
+    };
+
+    const handleDelete = (id: string) => {
+        console.log("Delete Question:", id);
+        alert("Delete clicked for id: " + id);
+    };
+
+    const handleDuplicate = (q: FormQuestion) => {
+        console.log("Duplicate Question:", q);
+        alert("Duplicate clicked");
+    };
+
+    return (
+        <div className="min-h-screen bg-muted/30 p-8 flex justify-center items-start">
+            <div className="w-full max-w-3xl space-y-6">
+                <div className="border-t-8 border-primary rounded-t-lg bg-card p-6 shadow-sm">
+                    <h1 className="text-3xl font-bold tracking-tight">Ripoff Google Form by KH test</h1>
+                    <p className="text-muted-foreground mt-2">
+                        Welcome to the awesome bootleg google form by KH mindblown emoji*
+                    </p>
+                </div>
+
+                <div className="bg-transparent">
+                    <QuestionEditCard
+                        question={question}
+                        isActive={true}
+                        onUpdate={handleUpdate}
+                        onDelete={handleDelete}
+                        onDuplicate={handleDuplicate}
+                    />
+                </div>
+
+            </div>
+
+            {/* <div className="p-4 bg-card rounded-md border shadow-sm">
+                <h2 className="text-lg font-semibold mb-2">Current State (Debug)</h2>
+                <pre className="text-xs overflow-auto max-h-96 text-muted-foreground font-mono bg-muted p-4 rounded">
+                    {JSON.stringify(question, null, 2)}
+                </pre>
+            </div> */}
+        </div>
+
+    );
+}

--- a/apps/blade/src/components/admin/forms/question-edit-card.tsx
+++ b/apps/blade/src/components/admin/forms/question-edit-card.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import * as React from "react";
+import {
+    AlignLeft,
+    Calendar,
+    CheckSquare,
+    ChevronDown,
+    Circle,
+    CircleDot,
+    Clock,
+    Copy,
+    MoreVertical,
+    Pilcrow,
+    Trash,
+    X,
+    GripHorizontal,
+} from "lucide-react";
+const uuidv4 = () => crypto.randomUUID();
+
+import { cn } from "@forge/ui";
+import { Button } from "@forge/ui/button";
+import { Card } from "@forge/ui/card";
+import { Input } from "@forge/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@forge/ui/select";
+import { Checkbox } from "@forge/ui/checkbox";
+import { Textarea } from "@forge/ui/textarea";
+
+import {
+    FormQuestion,
+    QuestionOption,
+    QuestionType,
+} from "~/lib/types/form";
+
+interface QuestionEditCardProps {
+    question: FormQuestion;
+    isActive: boolean;
+    onUpdate: (updatedQuestion: FormQuestion) => void;
+    onDelete: (id: string) => void;
+    onDuplicate: (question: FormQuestion) => void;
+}
+
+const QUESTION_TYPES: {
+    value: QuestionType;
+    label: string;
+    icon: React.ElementType;
+}[] = [
+        { value: "short_answer", label: "Short answer", icon: AlignLeft },
+        { value: "paragraph", label: "Paragraph", icon: Pilcrow },
+        { value: "multiple_choice", label: "Multiple choice", icon: CircleDot },
+        { value: "checkboxes", label: "Checkboxes", icon: CheckSquare },
+        { value: "dropdown", label: "Dropdown", icon: ChevronDown },
+        { value: "date", label: "Date", icon: Calendar },
+        { value: "time", label: "Time", icon: Clock },
+    ];
+
+export function QuestionEditCard({
+    question,
+    isActive,
+    onUpdate,
+    onDelete,
+    onDuplicate,
+}: QuestionEditCardProps) {
+    // -- Handlers --
+
+    const handleTitleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        onUpdate({ ...question, title: e.target.value });
+    };
+
+    const handleTypeChange = (newType: QuestionType) => {
+        let updatedQuestion = { ...question, type: newType };
+
+        if (
+            ["multiple_choice", "checkboxes", "dropdown"].includes(newType) &&
+            (!question.options || question.options.length === 0)
+        ) {
+            updatedQuestion.options = [{ id: uuidv4(), value: "Option 1", isOther: false }];
+        }
+
+        if (["short_answer", "paragraph", "date", "time"].includes(newType)) {
+            updatedQuestion.options = undefined;
+        }
+
+        onUpdate(updatedQuestion);
+    };
+
+    const handleRequiredChange = (checked: boolean) => {
+        onUpdate({ ...question, required: checked });
+    };
+
+    return (
+        <Card
+            className={cn(
+                "relative flex flex-col gap-4 border-l-4 p-6 transition-all bg-card text-card-foreground",
+                isActive ? "border-l-primary shadow-md ring-1 ring-black/5" : "border-l-transparent hover:bg-muted/50"
+            )}
+            onClick={(e) => {
+                e.stopPropagation();
+            }}
+        >
+
+
+            {/* Header */}
+            <div className="flex flex-col gap-4 md:flex-row md:items-start">
+                <div className="flex-1 bg-muted/50 p-2 rounded-md focus-within:bg-muted focus-within:ring-1 focus-within:ring-primary/20 transition-colors">
+                    <Textarea
+                        value={question.title}
+                        onChange={handleTitleChange}
+                        placeholder="Question"
+                        className="min-h-[3rem] resize-none overflow-hidden border-none bg-transparent text-lg font-medium placeholder:text-muted-foreground focus-visible:ring-0 px-0 py-0"
+                        rows={1}
+                        onInput={(e) => {
+                            // Auto-resize
+                            const target = e.target as HTMLTextAreaElement;
+                            target.style.height = "auto";
+                            target.style.height = `${target.scrollHeight}px`;
+                        }}
+                    />
+                </div>
+
+                <div className="w-full md:w-[220px]">
+                    <Select value={question.type} onValueChange={(val: QuestionType) => handleTypeChange(val)}>
+                        <SelectTrigger className="h-12 w-full">
+                            <SelectValue placeholder="Select type" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {QUESTION_TYPES.map((type) => (
+                                <SelectItem key={type.value} value={type.value}>
+                                    <div className="flex items-center gap-3">
+                                        <type.icon className="h-4 w-4" />
+                                        <span>{type.label}</span>
+                                    </div>
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+
+            {/* Body */}
+            <div className="pt-2">
+                <QuestionBody question={question} onUpdate={onUpdate} />
+            </div>
+
+            {/* Footer */}
+            <div className="mt-4 flex items-center justify-between gap-2 border-t pt-4">
+                <div className="cursor-move text-gray-300 hover:text-gray-500">
+                    <GripHorizontal className="h-5 w-5 rotate-90" />
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                    <div className="mr-4 flex items-center gap-2 border-r pr-4">
+                        <Copy
+                            className="h-5 w-5 cursor-pointer text-gray-500 hover:text-gray-700"
+                            onClick={() => onDuplicate(question)}
+                        />
+                        <Trash
+                            className="h-5 w-5 cursor-pointer text-gray-500 hover:text-red-600"
+                            onClick={() => onDelete(question.id)}
+                        />
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">Required</span>
+                        <Checkbox checked={question.required} onCheckedChange={handleRequiredChange} />
+                    </div>
+
+                    <div className="ml-2">
+                        <Button variant="ghost" size="icon">
+                            <MoreVertical className="h-5 w-5 text-gray-500" />
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </Card>
+    );
+}
+
+// -- Sub-Components --
+
+function QuestionBody({
+    question,
+    onUpdate,
+}: {
+    question: FormQuestion;
+    onUpdate: (q: FormQuestion) => void;
+}) {
+    switch (question.type) {
+        case "short_answer":
+            return (
+                <div className="w-1/2 border-b border-dotted border-gray-300 py-2 text-sm text-gray-400">
+                    Short answer text
+                </div>
+            );
+        case "paragraph":
+            return (
+                <div className="w-3/4 border-b border-dotted border-gray-300 py-2 text-sm text-gray-400">
+                    Long answer text
+                </div>
+            );
+        case "multiple_choice":
+        case "checkboxes":
+        case "dropdown":
+            return <OptionList question={question} onUpdate={onUpdate} />;
+        case "date":
+            return (
+                <div className="flex items-center gap-2 text-gray-400">
+                    <Calendar className="h-5 w-5" />
+                    <span>Month, day, year</span>
+                </div>
+            );
+        case "time":
+            return (
+                <div className="flex items-center gap-2 text-gray-400">
+                    <Clock className="h-5 w-5" />
+                    <span>Time</span>
+                </div>
+            );
+        default:
+            return null;
+    }
+}
+
+function OptionList({
+    question,
+    onUpdate,
+}: {
+    question: FormQuestion;
+    onUpdate: (q: FormQuestion) => void;
+}) {
+    const options = question.options || [];
+
+    const handleOptionChange = (id: string, newValue: string) => {
+        const newOptions = options.map((opt) =>
+            opt.id === id ? { ...opt, value: newValue } : opt
+        );
+        onUpdate({ ...question, options: newOptions });
+    };
+
+    const addOption = () => {
+        const newOption: QuestionOption = {
+            id: uuidv4(),
+            value: `Option ${options.length + 1}`,
+            isOther: false,
+        };
+        onUpdate({ ...question, options: [...options, newOption] });
+    };
+
+    const removeOption = (id: string) => {
+        const newOptions = options.filter((opt) => opt.id !== id);
+        onUpdate({ ...question, options: newOptions });
+    };
+
+    const Icon =
+        question.type === "multiple_choice"
+            ? Circle
+            : question.type === "checkboxes"
+                ? CheckSquare
+                : Circle;
+
+    return (
+        <div className="flex flex-col gap-2">
+            {options.map((option, idx) => (
+                <div key={option.id} className="group flex items-center gap-2">
+                    {question.type === "dropdown" ? (
+                        <span className="w-6 text-center text-sm">{idx + 1}.</span>
+                    ) : (
+                        <Icon className="h-5 w-5 text-gray-300" />
+                    )}
+
+                    <Input
+                        value={option.value}
+                        onChange={(e) => handleOptionChange(option.id, e.target.value)}
+                        className="flex-1 border-none hover:border-b hover:border-gray-200 focus:border-b-2 focus:border-blue-500 focus:ring-0 rounded-none px-0"
+                        placeholder={`Option ${idx + 1}`}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                e.preventDefault();
+                                addOption();
+                            }
+                            if (e.key === "Backspace" && option.value === "") {
+                                e.preventDefault();
+                                removeOption(option.id);
+                            }
+                        }}
+                        autoFocus={idx === options.length - 1 && options.length > 1}
+                    />
+
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={() => removeOption(option.id)}
+                        tabIndex={-1}
+                    >
+                        <X className="h-5 w-5 text-gray-500" />
+                    </Button>
+                </div>
+            ))}
+
+            {/* Add Option Button */}
+            <div className="flex items-center gap-2 mt-1">
+                {question.type === "dropdown" ? (
+                    <span className="w-6 text-center text-sm">{options.length + 1}.</span>
+                ) : (
+                    <Icon className="h-5 w-5 text-transparent" />
+                )}
+
+                <div className="flex items-center gap-1 text-sm text-gray-500">
+                    <Button
+                        variant="ghost"
+                        className="h-auto px-0 py-1 text-gray-500 hover:text-gray-800 hover:bg-transparent"
+                        onClick={addOption}
+                    >
+                        Add option
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/blade/src/lib/types/form.ts
+++ b/apps/blade/src/lib/types/form.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const QuestionTypeEnum = z.enum([
+  "short_answer",
+  "paragraph",
+  "multiple_choice",
+  "checkboxes",
+  "dropdown",
+  "date",
+  "time",
+]);
+
+export type QuestionType = z.infer<typeof QuestionTypeEnum>;
+
+// Option Schema for Choice Questions
+export const QuestionOptionSchema = z.object({
+  id: z.string().uuid(),
+  value: z.string(),
+  isOther: z.boolean().default(false), // Logic for "Other" option
+});
+
+export const FormQuestionSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1, "Question title is required"),
+  description: z.string().optional(),
+  type: QuestionTypeEnum,
+  required: z.boolean().default(false),
+
+  // Data specific to types
+  options: z.array(QuestionOptionSchema).optional(),
+  placeholder: z.string().optional(), // For text inputs
+
+  // Validation constraints (optional for V1 but good to have)
+  validation: z
+    .object({
+      min: z.number().optional(),
+      max: z.number().optional(),
+      regex: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type FormQuestion = z.infer<typeof FormQuestionSchema>;
+export type QuestionOption = z.infer<typeof QuestionOptionSchema>;


### PR DESCRIPTION
Built the form question editor component and a test page to try it out (looks pretty clean).
Supports multiple question types with dynamic UI and uses Zod schemas.

# Why
To support the new "Blade Form Manager" (which will replace Google Forms for our elections and applications), and needed to build the core frontend component that allows admins to actually create and edit questions. This PR delivers that standalone component so we can start building the larger form builder UI.


# What
I added the following:
QuestionEditCardComponent: The main UI for editing a single form question (apps/blade/src/components/admin/forms/question-edit-card.tsx). It looks like the Google Forms and has the following options so far:
Short Answer / Paragraph / Multiple Choice / Checkboxes / Dropdown / Date / Time
Zod Types: are on apps/blade/src/lib/types/form.ts with FormQuestionSchema and QuestionOptionSchema. 
To test it out (Dev): I added a temporary page at /admin/forms/test-editor to show and test the component without needing the full backend integration yet.


# Test Plan
I ran the blade app locally (pnpm dev:blade) and verified the component at http://localhost:3000/admin/forms/test-editor.
Interaction: confirmed that simple text inputs, type switching, and the "Required" toggle updates the state correctly.
Option Logic: tested adding, editing, and deleting options for multiple-choice/dropdown questions; ensure unique IDs are generated correctly using crypto.randomUUID().
Responsiveness: validated that the card layout holds up on smaller screens. 
(If any features are to be added feel free to add em in)
<img width="1901" height="981" alt="image" src="https://github.com/user-attachments/assets/475d38d7-bb82-4e9c-9b90-4d2a9af0b0fe" />
<img width="1894" height="1026" alt="image" src="https://github.com/user-attachments/assets/9f8a5309-6ce2-4324-84a5-6cb9921c4503" />


P.S. I will change the name and clean up descriptions after.
