### PR TITLE
Added resubmission and dues toggle in the backend

### DIFF
--- a/apps/blade/src/app/admin/forms/test-editor/page.tsx
+++ b/apps/blade/src/app/admin/forms/test-editor/page.tsx
@@ -115,14 +115,18 @@ export default function FormEditorPage() {
         : undefined;
 
     createFormMutation.mutate({
-      name: formTitle,
-      description: formDescription,
-      banner: bannerUrl,
-      questions: questions.map((q) => {
-        // Remove local 'id' before sending to backend
-        const { id: _id, ...rest } = q;
-        return rest;
-      }),
+      formData: {
+        name: formTitle,
+        description: formDescription,
+        banner: bannerUrl,
+        questions: questions.map((q) => {
+          // Remove local 'id' before sending to backend
+          const { id: _id, ...rest } = q;
+          return rest;
+        }),
+      },
+      duesOnly: true,
+      allowResubmission: true,
     });
   };
 

--- a/packages/db/src/schemas/knight-hacks.ts
+++ b/packages/db/src/schemas/knight-hacks.ts
@@ -535,9 +535,14 @@ export const InsertOtherCompaniesSchema = createInsertSchema(OtherCompanies);
 export const FormsSchemas = createTable("form_schemas", (t) => ({
   name: t.varchar({ length: 255 }).notNull().primaryKey(),
   createdAt: t.timestamp().notNull().defaultNow(),
+  duesOnly: t.boolean().notNull().default(false),
+  allowResubmission: t.boolean().notNull().default(false),
   formData: t.jsonb().notNull(),
   formValidatorJson: t.jsonb().notNull(),
 }));
+
+//Ts so dumb
+export const FormSchemaSchema = createInsertSchema(FormsSchemas);
 
 export const FormResponse = createTable("form_response", (t) => ({
   id: t.uuid().notNull().primaryKey().defaultRandom(),


### PR DESCRIPTION
# Why

We need more information for forms such as toggles for dues and resubmissions

# What

Changed backend to take in more information beyond just the formData. Also made sure to not hardcode these fields anywhere else other than the db schema so its trivial to add more of them in the future. Also returns all the info other than just formData and validator.

**Create forms takes in:**
- formData
- duesToggle
- allowResubmissions
Auto fills everything else

**getForm gives:**
gives all the fields in db + a zod validator string to be parsed

# Test Plan

https://github.com/user-attachments/assets/ea320a81-0c23-438f-ab1d-10a575a1bd33