### PR TITLE
Added ability to hook up functions to form responses

### DIFF
--- a/packages/api/src/routers/forms.ts
+++ b/packages/api/src/routers/forms.ts
@@ -29,13 +29,13 @@ type FormResponseCallBack = (userId: string, response: any) => undefined;
 
 /**
  Example form call back handler, please reference :pray:
- *const handle_goated_form_response = ((userId: string, response: { answer: string }) => {
+ *const handle_sample_form_response = ((userId: string, response: { answer: string }) => {
  *	console.log(userId, response);
  *}) satisfies FormResponseCallBack;
 */
 
 const handleCallbacks: Record<string, FormResponseCallBack> = {
-  //"goated-form": handle_goated_form_response,
+  //"sample-form": handle_sample_form_response,
 };
 
 export const formsRouter = {


### PR DESCRIPTION
# Why

Allows us to hook up whatever logic we want to form responses like member and hacker creation

# What

Just auto getting functions from a hashmap and calling them. Typing is something to be careful of and I've tried to maintain it but please look at the example for future procedures so it can properly typed. It's mainly just coercion by defining the type of Response argument to the type the form will be. Idk a better way to do it.

# Test Plan
https://github.com/user-attachments/assets/ce5b4a54-a0b3-4c37-92b7-5cacf2f1ea35