### PR TITLE
Db/truncate

### DIFF
--- a/packages/db/scripts/get_prod_db.ts
+++ b/packages/db/scripts/get_prod_db.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /**
  * Usage:
- *   pnpm --filter @forge/db with-env tsx scripts/get_prod_db.ts [--truncate]
+ *   pnpm --filter=@forge/db with-env tsx scripts/get_prod_db.ts [--truncate]
  *
  * Pass in --truncate if you want to truncate the entire database before
  * pushing the rows from prod.


### PR DESCRIPTION
# Why

Getting prod db didn't do row updates only insertions.

# What

Truncate all tables before getting and merging optionally in case of larger migrations and stuff (does unfortunately lose data but we can switch to upserts with sed replacing or smt eventually).

# Test Plan

Ran script with and without the option and it worked