### PR TITLE
[#345] Sort individual form responses view by time submitted, not by name

### DIFF
--- a/apps/blade/src/app/admin/forms/[slug]/responses/_components/PerUserResponsesView.tsx
+++ b/apps/blade/src/app/admin/forms/[slug]/responses/_components/PerUserResponsesView.tsx
@@ -92,13 +92,9 @@ export function PerUserResponsesView({
 
   const users = Object.values(groupedByUser).sort((a, b) => {
     const timeA =
-      a.length > 0
-        ? Math.min(...a.map((r) => r.submittedAt.getTime()))
-        : 0;
+      a.length > 0 ? Math.min(...a.map((r) => r.submittedAt.getTime())) : 0;
     const timeB =
-      b.length > 0
-        ? Math.min(...b.map((r) => r.submittedAt.getTime()))
-        : 0;
+      b.length > 0 ? Math.min(...b.map((r) => r.submittedAt.getTime())) : 0;
     return timeA - timeB;
   });
 


### PR DESCRIPTION
# Why

`/form/responses` gets all responses from a form and displays them in alphabetical order. it should be chronological, starting with the first person.


# What

Issue(s): [#345](https://github.com/KnightHacks/forge/issues/345)

Sorts responses by time submitted rather than name.

# Test Plan

Merge me twin.

## Checklist

- [x] Database: No schema changes, OR I have contacted the Development Lead to run `db:push` before merging
- [x] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin responses view: grouped user responses now sort by each group’s earliest submission time rather than alphabetically by user name, so submission order is clearer for administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->