### PR TITLE
[#351] Filter recurring OPS and PL lab events from next week reminders

### DIFF
--- a/apps/cron/src/crons/reminder.ts
+++ b/apps/cron/src/crons/reminder.ts
@@ -402,7 +402,7 @@ async function getEvents() {
 
   console.log("Next Week's Events: ", nextWeekEvents);
 
-  // Filter out "Operations Meeting" from nextWeek
+  // Filter out "Operations Meeting" and "Project Launch Lab Hours" from nextWeek
   const nextWeekFiltered = nextWeekEvents.filter((event) => {
     const tag = event.tag.toLowerCase();
     const name = event.name.toLowerCase();


### PR DESCRIPTION
# Why

Recurring OPS and PL lab events don't need next week reminders since they are weekly events. This created unnecessary noise in the discord reminders.

# What

Issue(s): #351 

- Filtered events with the "OPS" tag
- Filtered events with the "Project Launch" tag  and "Lab" or "Hours" name

# Test Plan

- Validated filtering logic with similar sample events
- <img width="525" height="286" alt="Screenshot 2026-02-11 at 3 37 44 PM" src="https://github.com/user-attachments/assets/f500f079-5f5f-4a0f-b0a3-3ac2bff97770" />


## Checklist

- [x] Database: No schema changes, OR I have contacted the Development Lead to run `db:push` before merging
- [x] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined reminder event filtering to use case-insensitive matching and clearer exclusion rules—now consistently excludes Operations events and Project Launch events related to lab hours while preserving existing grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->