### PR TITLE
fix: switch delete to trash and add dialogue for forms

### DIFF
--- a/apps/blade/src/app/admin/forms/[slug]/responses/_components/PerUserResponsesView.tsx
+++ b/apps/blade/src/app/admin/forms/[slug]/responses/_components/PerUserResponsesView.tsx
@@ -12,12 +12,20 @@ import {
   FileSpreadsheet,
   FileText,
   Loader2,
-  X,
+  Trash2,
 } from "lucide-react";
 
 import type { FORMS } from "@forge/consts";
 import { Button } from "@forge/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@forge/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@forge/ui/dialog";
 import { Separator } from "@forge/ui/separator";
 import { toast } from "@forge/ui/toast";
 
@@ -261,12 +269,14 @@ export function PerUserResponsesView({
 }
 
 function DeleteResponseButton({ responseId }: { responseId: string }) {
+  const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
   const utils = api.useUtils();
 
   const deleteResponse = api.forms.deleteResponse.useMutation({
     async onSuccess() {
       toast.success("Response deleted");
+      setIsOpen(false);
       await utils.forms.getResponses.invalidate();
       router.refresh();
     },
@@ -276,19 +286,48 @@ function DeleteResponseButton({ responseId }: { responseId: string }) {
   });
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={() => deleteResponse.mutate({ id: responseId })}
-      disabled={deleteResponse.isPending}
-      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-    >
-      {deleteResponse.isPending ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <X className="h-4 w-4" />
-      )}
-    </Button>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Delete response"
+          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete Response</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          Are you sure you want to delete this response? This action cannot be
+          undone.
+        </p>
+        <DialogFooter className="mt-4">
+          <Button
+            variant="outline"
+            onClick={() => setIsOpen(false)}
+            disabled={deleteResponse.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => deleteResponse.mutate({ id: responseId })}
+            disabled={deleteResponse.isPending}
+          >
+            {deleteResponse.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              "Delete"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
# Why

The remove-response action in per-user form responses used a generic cross icon and deleted immediately on click. This made the destructive action less clear and increased risk of accidental deletions.

# What

Issue(s):
- N/A (no linked issue provided)

Changes made:
- Updated the remove-response action icon from `X` to `Trash2` in:
  - `/Users/carlos/Development/forge/apps/blade/src/app/admin/forms/[slug]/responses/_components/PerUserResponsesView.tsx`
- Added a confirmation dialog before deleting a response.
  - Dialog includes:
    - Title: `Delete Response`
    - Warning text that the action is irreversible
    - `Cancel` and `Delete` actions
- Preserved existing mutation behavior:
  - Shows loading spinner while deleting
  - Shows success/error toast
  - Invalidates responses query and refreshes router on success
  - Closes dialog on successful delete

# Test Plan

- Ran targeted lint:
  - `pnpm --filter @forge/blade lint 'src/app/admin/forms/[slug]/responses/_components/PerUserResponsesView.tsx'`
  - Result: pass
- Ran app typecheck:
  - `pnpm --filter @forge/blade typecheck`
  - Result: pass

## Checklist

- [x] Database: No schema changes, OR I have contacted the Development Lead to run `db:push` before merging
- [x] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added modal confirmation dialog for deleting responses, requiring explicit user confirmation before permanent removal.
  * Automatic cache refresh after successful deletion.

* **UI/UX Improvements**
  * Updated delete button with new icon and refined interaction pattern.
  * Incorporated cancel option in confirmation flow; maintains loading states and error notifications throughout the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->