### PR TITLE
[#375] Add support for auto linking and closing issues in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -9,10 +9,10 @@ Please describe the motivation for this PR.
 <!--
 If need be, change closes to a more applicable keyword.
 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-Examples: "closes #67"; "resolves #420"; "closes: #128, fixes: #64"
+Examples: "Closes: #67"; "Resolves: #420"; "Closes: #128, fixes: #64"
 -->
 
-closes #ISSUE_NUMBER
+Closes: #ISSUE_NUMBER
 
 <!--
 Please describe the changes made in this PR.


### PR DESCRIPTION
# Why

PRs should automatically close their respective issue(s).

# What

fixes #375 

Sets the default issue linking keyword to `closes`, rather than `Issue(s):`, to allow for GitHub features to automatically link.

See [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) for more info.

# Test Plan

out of scope

## Checklist

<!--
IMPORTANT: Non-automated step. Make sure to confirm this, or Prod will go down.
-->

- [X] Database: No schema changes, OR I have contacted the Development Lead to run `db:push` before merging
- [X] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the pull request template: replaced the generic Issue placeholder with a clear HTML comment that explains how to link a PR to an issue and includes a default "Closes: #ISSUE_NUMBER" directive. No other template sections or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->