### PR TITLE
css changes and hacker application speed up

### DIFF
--- a/apps/blade/src/app/_components/dashboard/hacker/hackbackgrounds/bloomknights.ts
+++ b/apps/blade/src/app/_components/dashboard/hacker/hackbackgrounds/bloomknights.ts
@@ -15,13 +15,15 @@ const BLOOMKNIGHTS_BIRD_SVG =
 
 export const bloomknightsApplicationStyles = `
 @keyframes khBloomLeafFieldA {
-  0%, 100% { transform: translate3d(-90%, 0, 0) rotate(-10deg); }
-  48% { transform: translate3d(120%, 70%, 0) rotate(48deg); }
+  0%, 100% { transform: translate3d(-0.35rem, 2vh, 0) rotate(-24deg) scale(1); }
+  42% { transform: translate3d(1.45rem, -8vh, 0) rotate(86deg) scale(1.18); }
+  72% { transform: translate3d(-1.1rem, 9vh, 0) rotate(154deg) scale(0.96); }
 }
 
 @keyframes khBloomLeafFieldB {
-  0%, 100% { transform: translate3d(90%, 0, 0) rotate(14deg); }
-  52% { transform: translate3d(-120%, -60%, 0) rotate(-44deg); }
+  0%, 100% { transform: translate3d(0.4rem, 3vh, 0) rotate(22deg) scale(1.05); }
+  38% { transform: translate3d(-1.6rem, -9vh, 0) rotate(-88deg) scale(0.94); }
+  76% { transform: translate3d(1.2rem, 10vh, 0) rotate(-166deg) scale(1.2); }
 }
 
 @keyframes khBloomBirdGlideA {
@@ -34,6 +36,18 @@ export const bloomknightsApplicationStyles = `
   0% { transform: translate3d(18vw, 0, 0) scaleX(-1) scale(0.48); }
   52% { transform: translate3d(-12vw, 2vh, 0) scaleX(-1) scale(0.44); }
   100% { transform: translate3d(-42vw, -1vh, 0) scaleX(-1) scale(0.48); }
+}
+
+@keyframes khBloomBirdGlideC {
+  0% { transform: translate3d(-22vw, 1vh, 0) scale(0.34); }
+  46% { transform: translate3d(16vw, -1.5vh, 0) scale(0.38); }
+  100% { transform: translate3d(46vw, 0, 0) scale(0.34); }
+}
+
+@keyframes khBloomBirdGlideD {
+  0% { transform: translate3d(30vw, -1vh, 0) scaleX(-1) scale(0.32); }
+  54% { transform: translate3d(-8vw, 1.5vh, 0) scaleX(-1) scale(0.36); }
+  100% { transform: translate3d(-38vw, 0, 0) scaleX(-1) scale(0.32); }
 }
 
 @keyframes khBloomGodrayDrift {
@@ -149,7 +163,7 @@ export const bloomknightsApplicationStyles = `
   pointer-events: none;
   overflow: hidden;
   contain: paint;
-  clip-path: inset(60% 0 0 0);
+  clip-path: inset(48% 0 -8% 0);
   transform: translateZ(0);
 }
 
@@ -158,7 +172,7 @@ export const bloomknightsApplicationStyles = `
   backface-visibility: hidden;
   content: "";
   position: absolute;
-  width: clamp(0.6rem, 0.32%, 1.05rem);
+  width: clamp(1.1rem, 1.45vw, 2.2rem);
   aspect-ratio: 42 / 24;
   border-radius: 100% 0 100% 0;
   background:
@@ -179,7 +193,7 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-a::after {
   left: 22%;
   top: 76%;
-  width: clamp(0.52rem, 0.26%, 0.9rem);
+  width: clamp(0.95rem, 1.2vw, 1.85rem);
   animation: khBloomLeafFieldB 30s ease-in-out infinite;
   animation-delay: -7s;
 }
@@ -187,7 +201,7 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-b::before {
   left: 38%;
   top: 68%;
-  width: clamp(0.5rem, 0.24%, 0.88rem);
+  width: clamp(1rem, 1.22vw, 1.9rem);
   animation: khBloomLeafFieldB 28s ease-in-out infinite;
   animation-delay: -10s;
 }
@@ -195,7 +209,7 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-b::after {
   left: 51%;
   top: 83%;
-  width: clamp(0.45rem, 0.22%, 0.8rem);
+  width: clamp(0.9rem, 1.05vw, 1.7rem);
   animation: khBloomLeafFieldA 32s ease-in-out infinite;
   animation-delay: -16s;
 }
@@ -203,7 +217,7 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-c::before {
   left: 64%;
   top: 62%;
-  width: clamp(0.55rem, 0.28%, 0.95rem);
+  width: clamp(1.05rem, 1.35vw, 2.05rem);
   animation: khBloomLeafFieldA 29s ease-in-out infinite;
   animation-delay: -13s;
 }
@@ -211,7 +225,7 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-c::after {
   left: 78%;
   top: 74%;
-  width: clamp(0.48rem, 0.23%, 0.82rem);
+  width: clamp(0.92rem, 1.12vw, 1.75rem);
   animation: khBloomLeafFieldB 34s ease-in-out infinite;
   animation-delay: -21s;
 }
@@ -219,7 +233,7 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-d::before {
   left: 88%;
   top: 66%;
-  width: clamp(0.5rem, 0.24%, 0.86rem);
+  width: clamp(0.98rem, 1.18vw, 1.85rem);
   animation: khBloomLeafFieldB 31s ease-in-out infinite;
   animation-delay: -18s;
 }
@@ -227,9 +241,73 @@ export const bloomknightsApplicationStyles = `
 .kh-bloom-leaves-d::after {
   left: 93%;
   top: 86%;
-  width: clamp(0.42rem, 0.2%, 0.74rem);
+  width: clamp(0.82rem, 0.98vw, 1.55rem);
   animation: khBloomLeafFieldA 36s ease-in-out infinite;
   animation-delay: -24s;
+}
+
+.kh-bloom-leaves-e::before {
+  left: 13%;
+  top: 87%;
+  width: clamp(0.9rem, 1.08vw, 1.7rem);
+  animation: khBloomLeafFieldB 33s ease-in-out infinite;
+  animation-delay: -20s;
+}
+
+.kh-bloom-leaves-e::after {
+  left: 31%;
+  top: 59%;
+  width: clamp(1.02rem, 1.28vw, 1.95rem);
+  animation: khBloomLeafFieldA 27s ease-in-out infinite;
+  animation-delay: -12s;
+}
+
+.kh-bloom-leaves-f::before {
+  left: 45%;
+  top: 90%;
+  width: clamp(0.86rem, 1vw, 1.6rem);
+  animation: khBloomLeafFieldA 35s ease-in-out infinite;
+  animation-delay: -26s;
+}
+
+.kh-bloom-leaves-f::after {
+  left: 58%;
+  top: 57%;
+  width: clamp(1.08rem, 1.38vw, 2.1rem);
+  animation: khBloomLeafFieldB 29s ease-in-out infinite;
+  animation-delay: -15s;
+}
+
+.kh-bloom-leaves-g::before {
+  left: 70%;
+  top: 88%;
+  width: clamp(0.88rem, 1.04vw, 1.65rem);
+  animation: khBloomLeafFieldB 37s ease-in-out infinite;
+  animation-delay: -29s;
+}
+
+.kh-bloom-leaves-g::after {
+  left: 84%;
+  top: 58%;
+  width: clamp(1rem, 1.26vw, 1.95rem);
+  animation: khBloomLeafFieldA 28s ease-in-out infinite;
+  animation-delay: -19s;
+}
+
+.kh-bloom-leaves-h::before {
+  left: 5%;
+  top: 54%;
+  width: clamp(0.94rem, 1.14vw, 1.78rem);
+  animation: khBloomLeafFieldA 31s ease-in-out infinite;
+  animation-delay: -23s;
+}
+
+.kh-bloom-leaves-h::after {
+  left: 96%;
+  top: 55%;
+  width: clamp(0.9rem, 1.08vw, 1.68rem);
+  animation: khBloomLeafFieldB 39s ease-in-out infinite;
+  animation-delay: -31s;
 }
 
 .kh-bloom-birds-far {
@@ -243,6 +321,22 @@ export const bloomknightsApplicationStyles = `
   top: 16%;
   animation: khBloomBirdGlideB 48s ease-in-out infinite;
   animation-delay: -18s;
+}
+
+.kh-bloom-birds-high {
+  left: 28%;
+  top: 6%;
+  width: clamp(1.9rem, 3.8vw, 3.3rem);
+  animation: khBloomBirdGlideC 54s ease-in-out infinite;
+  animation-delay: -28s;
+}
+
+.kh-bloom-birds-mid {
+  right: 30%;
+  top: 22%;
+  width: clamp(2rem, 4.2vw, 3.6rem);
+  animation: khBloomBirdGlideD 58s ease-in-out infinite;
+  animation-delay: -36s;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -273,25 +367,49 @@ export const bloomknightsApplicationBackground = {
     {
       id: "bloomknights-leaves-a",
       className: "kh-bloom-leaf-field kh-bloom-leaves-a",
-      space: "viewport",
+      space: "scene",
       zIndex: 3,
     },
     {
       id: "bloomknights-leaves-b",
       className: "kh-bloom-leaf-field kh-bloom-leaves-b",
-      space: "viewport",
+      space: "scene",
       zIndex: 3,
     },
     {
       id: "bloomknights-leaves-c",
       className: "kh-bloom-leaf-field kh-bloom-leaves-c",
-      space: "viewport",
+      space: "scene",
       zIndex: 3,
     },
     {
       id: "bloomknights-leaves-d",
       className: "kh-bloom-leaf-field kh-bloom-leaves-d",
-      space: "viewport",
+      space: "scene",
+      zIndex: 3,
+    },
+    {
+      id: "bloomknights-leaves-e",
+      className: "kh-bloom-leaf-field kh-bloom-leaves-e",
+      space: "scene",
+      zIndex: 3,
+    },
+    {
+      id: "bloomknights-leaves-f",
+      className: "kh-bloom-leaf-field kh-bloom-leaves-f",
+      space: "scene",
+      zIndex: 3,
+    },
+    {
+      id: "bloomknights-leaves-g",
+      className: "kh-bloom-leaf-field kh-bloom-leaves-g",
+      space: "scene",
+      zIndex: 3,
+    },
+    {
+      id: "bloomknights-leaves-h",
+      className: "kh-bloom-leaf-field kh-bloom-leaves-h",
+      space: "scene",
       zIndex: 3,
     },
   ],
@@ -304,7 +422,7 @@ export const bloomknightsApplicationBackground = {
       nativeSize: BLOOMKNIGHTS_SCENE_SIZE,
       sources: [
         {
-          media: "(max-width: 1024px)",
+          media: "(max-height: 1440px)",
           mimeType: "image/webp",
           src: BLOOMKNIGHTS_APPLICATION_TABLET_WEBP,
         },
@@ -345,13 +463,41 @@ export const bloomknightsApplicationBackground = {
       className: "kh-bloom-birds kh-bloom-birds-near",
       zIndex: 2,
     },
+    {
+      id: "bloomknights-birds-high",
+      kind: "image",
+      mediaClassName: "h-auto w-full",
+      nativeSize: {
+        height: 36,
+        width: 96,
+      },
+      opacity: 0.58,
+      src: BLOOMKNIGHTS_BIRD_SVG,
+      space: "viewport",
+      className: "kh-bloom-birds kh-bloom-birds-high",
+      zIndex: 2,
+    },
+    {
+      id: "bloomknights-birds-mid",
+      kind: "image",
+      mediaClassName: "h-auto w-full",
+      nativeSize: {
+        height: 36,
+        width: 96,
+      },
+      opacity: 0.54,
+      src: BLOOMKNIGHTS_BIRD_SVG,
+      space: "viewport",
+      className: "kh-bloom-birds kh-bloom-birds-mid",
+      zIndex: 2,
+    },
   ],
   mode: "dynamic",
   overlayClassName:
     "bg-[linear-gradient(90deg,rgba(5,18,22,0.6)_0%,rgba(8,32,42,0.38)_48%,rgba(8,23,31,0.2)_100%)]",
-  questionTransitionMs: 420,
+  questionTransitionMs: 0,
   showStockEffects: false,
-  stepTransitionMs: 560,
+  stepTransitionMs: 220,
   styles: bloomknightsApplicationStyles,
-  transitionMs: 560,
+  transitionMs: 220,
 } satisfies ApplicationVisualConfig;

--- a/apps/blade/src/app/_components/dashboard/hacker/hacker-application-form.tsx
+++ b/apps/blade/src/app/_components/dashboard/hacker/hacker-application-form.tsx
@@ -142,7 +142,7 @@ const applicationAnimationStyles = `
 }
 
 .kh-step-title {
-  animation: khTitleRise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: khTitleRise 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .kh-submit-loading {
@@ -176,16 +176,16 @@ const applicationAnimationStyles = `
 }
 
 .kh-step-content > section > div:not(.hidden) {
-  animation: khFieldIn 460ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: khFieldIn 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.kh-step-content > section > div:not(.hidden):nth-child(2) { animation-delay: 45ms; }
-.kh-step-content > section > div:not(.hidden):nth-child(3) { animation-delay: 90ms; }
-.kh-step-content > section > div:not(.hidden):nth-child(4) { animation-delay: 135ms; }
-.kh-step-content > section > div:not(.hidden):nth-child(5) { animation-delay: 180ms; }
-.kh-step-content > section > div:not(.hidden):nth-child(6) { animation-delay: 225ms; }
-.kh-step-content > section > div:not(.hidden):nth-child(7) { animation-delay: 270ms; }
-.kh-step-content > section > div:not(.hidden):nth-child(8) { animation-delay: 315ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(2) { animation-delay: 20ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(3) { animation-delay: 40ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(4) { animation-delay: 60ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(5) { animation-delay: 80ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(6) { animation-delay: 100ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(7) { animation-delay: 120ms; }
+.kh-step-content > section > div:not(.hidden):nth-child(8) { animation-delay: 140ms; }
 
 .kh-step-content :is(input, textarea, button:not(.kh-resume-info-trigger)):focus-visible {
   animation: khUnderlinePulse 1.8s ease-in-out infinite;
@@ -1191,7 +1191,7 @@ export function HackerFormPage({
         }, handleInvalidSubmit)}
       >
         <div
-          className="kh-application-shell relative min-h-svh overflow-x-hidden bg-[linear-gradient(135deg,#10071d_0%,#271148_48%,#0b0614_100%)] text-white"
+          className="kh-application-shell relative h-svh min-h-svh overflow-hidden bg-[linear-gradient(135deg,#10071d_0%,#271148_48%,#0b0614_100%)] text-white"
           data-application-visual={applicationVisualKey}
         >
           <HackerApplicationBackground
@@ -1203,7 +1203,7 @@ export function HackerFormPage({
           {applicationSubmitted ? (
             <main
               aria-live="polite"
-              className="kh-readable-text kh-submitted-screen relative z-10 flex min-h-svh w-full flex-col px-5 py-8 sm:px-6 md:px-20 md:py-14"
+              className="kh-readable-text kh-submitted-screen relative z-10 flex h-svh min-h-svh w-full flex-col overflow-y-auto overscroll-contain px-5 py-8 sm:px-6 md:px-20 md:py-14"
             >
               <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-widest text-white/60">
                 <span>{hackathonName}</span>
@@ -1248,7 +1248,7 @@ export function HackerFormPage({
               </section>
             </main>
           ) : (
-            <div className="kh-readable-text relative z-10 flex min-h-svh w-full flex-col px-5 pb-32 pt-5 sm:px-6 md:px-20 md:pb-28 md:pt-14">
+            <div className="kh-readable-text relative z-10 flex h-svh min-h-svh w-full flex-col overflow-y-auto overscroll-contain px-5 pb-[calc(8rem+env(safe-area-inset-bottom))] pt-5 sm:px-6 md:px-20 md:pb-[calc(7.5rem+env(safe-area-inset-bottom))] md:pt-14">
               <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-widest text-white/60">
                 <span>{currentStep.eyebrow}</span>
                 <span>
@@ -1274,7 +1274,7 @@ export function HackerFormPage({
                   <div
                     className={cn(
                       "kh-step-content",
-                      "animate-in fade-in mt-10 duration-500 sm:mt-14 md:mt-16",
+                      "animate-in fade-in mt-10 duration-200 sm:mt-14 md:mt-16",
                       stepDirection === "forward"
                         ? "slide-in-from-right-4"
                         : "slide-in-from-left-4",
@@ -2179,7 +2179,7 @@ export function HackerFormPage({
                     </section>
                   </div>
 
-                  <div className="kh-application-nav fixed inset-x-5 bottom-5 z-30 flex items-center justify-between gap-3 [bottom:calc(1.25rem+env(safe-area-inset-bottom))] md:inset-x-16 md:bottom-10">
+                  <div className="kh-application-nav pointer-events-none fixed inset-x-5 bottom-0 z-30 flex items-center justify-between gap-3 pb-[calc(1.25rem+env(safe-area-inset-bottom))] md:inset-x-16 md:pb-10">
                     <Button
                       type="button"
                       variant="outline"
@@ -2188,7 +2188,10 @@ export function HackerFormPage({
                         activeStep === 0 || loading || isStepTransitioning
                       }
                       size="icon"
-                      className={secondaryActionButtonClassName}
+                      className={cn(
+                        secondaryActionButtonClassName,
+                        "pointer-events-auto",
+                      )}
                       aria-label="Back"
                       title="Back"
                     >
@@ -2196,7 +2199,7 @@ export function HackerFormPage({
                     </Button>
 
                     {isFinalStep ? (
-                      <div className="flex min-w-0 items-center gap-3">
+                      <div className="pointer-events-auto flex min-w-0 items-center gap-3">
                         {loading && (
                           <div
                             aria-live="polite"
@@ -2216,6 +2219,7 @@ export function HackerFormPage({
                           size="icon"
                           className={cn(
                             actionButtonClassName,
+                            "pointer-events-auto",
                             loading && "cursor-wait disabled:opacity-100",
                           )}
                           aria-label={
@@ -2242,7 +2246,10 @@ export function HackerFormPage({
                         onClick={() => void goToStep(activeStep + 1)}
                         disabled={loading || isStepTransitioning}
                         size="icon"
-                        className={actionButtonClassName}
+                        className={cn(
+                          actionButtonClassName,
+                          "pointer-events-auto",
+                        )}
                         aria-label="Next"
                         title="Next"
                       >

--- a/apps/bloomknights/next.config.js
+++ b/apps/bloomknights/next.config.js
@@ -4,6 +4,7 @@ const config = {
   images: {
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 30,
+    qualities: [72, 75],
     remotePatterns: [
       {
         protocol: "https",

--- a/apps/bloomknights/src/app/_components/about/about.tsx
+++ b/apps/bloomknights/src/app/_components/about/about.tsx
@@ -123,6 +123,8 @@ const About = () => {
                       : "(min-width: 1536px) 544px, (min-width: 1181px) 320px, (min-width: 768px) 360px, 62vw"
                   }
                   quality={72}
+                  loading="eager"
+                  fetchPriority={imageIndex === 0 ? "high" : "auto"}
                   className="about-gemiknight-image"
                 />
               </motion.figure>

--- a/apps/bloomknights/src/app/_components/graphics/BloomAssetPreloads.tsx
+++ b/apps/bloomknights/src/app/_components/graphics/BloomAssetPreloads.tsx
@@ -1,0 +1,22 @@
+export default function BloomAssetPreloads() {
+  return (
+    <>
+      <link
+        key="bloom-background-mobile"
+        rel="preload"
+        href="https://assets.knighthacks.org/bloom-background-mobile.avif"
+        as="image"
+        type="image/avif"
+        media="(max-width: 767px)"
+      />
+      <link
+        key="bloom-background-desktop"
+        rel="preload"
+        href="https://assets.knighthacks.org/bloom-background-desktop.avif"
+        as="image"
+        type="image/avif"
+        media="(min-width: 768px)"
+      />
+    </>
+  );
+}

--- a/apps/bloomknights/src/app/layout.tsx
+++ b/apps/bloomknights/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 
 import Footer from "./_components/footer/footer";
 import AnimatedBirds from "./_components/graphics/AnimatedBirds";
+import BloomAssetPreloads from "./_components/graphics/BloomAssetPreloads";
 import FloatingFlowers from "./_components/graphics/FloatingFlowers";
 import FlowerCursor from "./_components/graphics/Flowercursor";
 import ParallaxBackground from "./_components/graphics/ParallaxBackground";
@@ -110,6 +111,7 @@ export default function RootLayout({
       className={`${fredokaOne.variable} ${righteous.variable} ${dmSans.variable} h-full`}
     >
       <body className="bloom-site-background flex min-h-screen flex-col antialiased">
+        <BloomAssetPreloads />
         <ParallaxBackground />
         <AnimatedBirds />
         <FloatingFlowers />

--- a/apps/khix/src/app/globals.css
+++ b/apps/khix/src/app/globals.css
@@ -579,6 +579,7 @@ body {
 
 .khix-button {
   position: relative;
+  isolation: isolate;
   display: inline-flex;
   flex: 1 1 0;
   align-items: center;
@@ -608,7 +609,8 @@ body {
   content: "";
   position: absolute;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
+  pointer-events: none;
   -webkit-clip-path: polygon(
     1rem 0,
     calc(100% - 1rem) 0,
@@ -645,8 +647,11 @@ body {
 }
 
 .khix-button-label {
+  position: relative;
+  z-index: 2;
   display: block;
   width: 100%;
+  color: inherit;
   text-align: center;
 }
 
@@ -663,7 +668,8 @@ body {
   content: "";
   position: absolute;
   inset: 1px;
-  z-index: -1;
+  z-index: 1;
+  pointer-events: none;
   -webkit-clip-path: polygon(
     calc(1rem - 1px) 0,
     calc(100% - 1rem + 1px) 0,

--- a/apps/khix/src/app/globals.css
+++ b/apps/khix/src/app/globals.css
@@ -1447,6 +1447,17 @@ body {
 
   .khix-event-date-text {
     font-size: clamp(0.95rem, 4.2vw, 1.15rem);
+    text-shadow:
+      0 0 0.1rem rgba(255, 255, 255, 0.4),
+      0 0 0.3rem rgba(214, 255, 86, 0.15),
+      0 0.5rem 1rem rgba(0, 0, 0, 0.5);
+  }
+
+  .khix-event-location-text {
+    text-shadow:
+      0 0 0.08rem rgba(255, 255, 255, 0.35),
+      0 0 0.25rem rgba(214, 255, 86, 0.12),
+      0 0.45rem 0.85rem rgba(0, 0, 0, 0.42);
   }
 
   .khix-hero-actions {

--- a/apps/khix/src/app/page.tsx
+++ b/apps/khix/src/app/page.tsx
@@ -6,10 +6,10 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import {
   FaDiscord,
-  FaFacebook,
+  FaGithub,
   FaInstagram,
   FaLink,
-  FaTwitter,
+  FaLinkedin,
   FaVolumeMute,
   FaVolumeUp,
 } from "react-icons/fa";
@@ -17,12 +17,12 @@ import {
 import {
   APPLICATION_URL,
   DISCORD_URL,
-  FACEBOOK_URL,
+  GITHUB_URL,
   INSTAGRAM_URL,
+  LINKEDIN_URL,
   LINKTREE_URL,
   SEO_DESCRIPTION,
   SPONSOR_URL,
-  TWITTER_URL,
 } from "./seo";
 
 const mlhCodeOfConductUrl = "https://mlh.io/code-of-conduct";
@@ -63,14 +63,14 @@ const socialLinks = [
     Icon: FaInstagram,
   },
   {
-    label: "Facebook",
-    href: FACEBOOK_URL,
-    Icon: FaFacebook,
+    label: "LinkedIn",
+    href: LINKEDIN_URL,
+    Icon: FaLinkedin,
   },
   {
-    label: "Twitter",
-    href: TWITTER_URL,
-    Icon: FaTwitter,
+    label: "GitHub",
+    href: GITHUB_URL,
+    Icon: FaGithub,
   },
   {
     label: "Linktree",

--- a/apps/khix/src/app/seo.ts
+++ b/apps/khix/src/app/seo.ts
@@ -10,8 +10,8 @@ export const APPLICATION_URL = "https://blade.knighthacks.org/";
 export const SPONSOR_URL = "https://blade.knighthacks.org/sponsor";
 export const DISCORD_URL = "https://discord.knighthacks.org/";
 export const INSTAGRAM_URL = "https://www.instagram.com/knighthacks/";
-export const FACEBOOK_URL = "https://www.facebook.com/KnightHacks/";
-export const TWITTER_URL = "https://www.twitter.com/KnightHacks/";
+export const LINKEDIN_URL = "https://www.linkedin.com/company/knight-hacks";
+export const GITHUB_URL = "https://github.com/knighthacks";
 export const LINKTREE_URL = "https://linktr.ee/knighthacks";
 
 export const SEO_TITLE =
@@ -48,8 +48,8 @@ export const SEO_KEYWORDS = [
 export const SOCIAL_PROFILE_URLS = [
   DISCORD_URL,
   INSTAGRAM_URL,
-  FACEBOOK_URL,
-  TWITTER_URL,
+  LINKEDIN_URL,
+  GITHUB_URL,
   LINKTREE_URL,
 ];
 


### PR DESCRIPTION
# Why

Fixes the BloomKnights/KHIX mobile polish issues from #464. The BloomKnights application background needed to feel like one continuous scene instead of having viewport-pinned effects repeat

# What

Closes: #464

- Updated the BloomKnights hacker application background so leaves live in scene space, with more leaves and birds added.
- Tightened the hacker application step transitions, scroll behavior, and fixed bottom nav behavior.
- Added BloomKnights background preloads and kept key images eager.
- Included KHIX mobile/SEO polish from this branch.
- Compressed background more too 

# Test Plan

- `git diff --check`
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `NODE_ENV=production pnpm build`
- `pnpm lint:ws` exits 0 with existing workspace warning for missing `packages/transactional/package.json`

## Checklist

- [x] Database: No schema changes, or env stuff 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset preloading for optimized image delivery across device sizes.

* **Performance**
  * Enhanced image loading optimization with eager loading for critical gallery images.
  * Improved animation timing and transitions throughout the application.
  * Updated Next.js image optimization configuration.

* **Updates**
  * Replaced Facebook and Twitter social links with GitHub and LinkedIn.

* **Style**
  * Refined animations, visual styling, and UI layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->