### PR TITLE
[#467] Document repo and database conventions for agents

### DIFF
--- a/.cursor/rules/forge-agent-instructions.mdc
+++ b/.cursor/rules/forge-agent-instructions.mdc
@@ -1,0 +1,5 @@
+---
+alwaysApply: true
+---
+
+Follow the repository-level agent instructions in `AGENTS.md`. Treat `AGENTS.md` as the canonical source for Forge agent behavior, scope control, checks, commit hygiene, and PR expectations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# Forge Agent Instructions
+
+Instructions for AI coding agents working in Forge, including Codex, Claude Code, and similar tools.
+
+Forge is a public Knight Hacks monorepo. Treat agent output as production-quality contribution work, not throwaway code.
+
+## Before editing
+
+Read the relevant project context first:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `docs/GETTING-STARTED.md`
+- `docs/GITHUB-ETIQUETTE.md`
+- Any task-relevant files in `docs/`
+
+Search for existing patterns before adding new helpers, components, dependencies, routes, schema fields, or workflows.
+
+## Reverse-prompt and branch first
+
+Before non-trivial edits, restate the task back to the human:
+
+- goal
+- intended app/package scope
+- likely files involved
+- planned checks
+- assumptions, tradeoffs, or unclear requirements
+
+Prefer plan mode or an explicit written plan for multi-file, cross-package, database, dependency, or UI behavior changes. Ask for clarification when scope is ambiguous.
+
+As soon as changes are proposed or approved, create a task branch before editing. Do not work directly on `main`.
+
+## Keep scope tight
+
+Make the smallest change that correctly accomplishes the task.
+
+Forge is a monorepo. A PR should usually be scoped to one `apps/*` app plus only the `packages/*` changes that app truly needs.
+
+- `apps/club` changes should not alter Blade behavior.
+- `apps/blade` changes should not alter Club behavior.
+- Do not touch other apps unless the task explicitly names them.
+- Put shared behavior in `packages/*` only when multiple consumers need it.
+- If changing `packages/*`, consider and test the affected consumers.
+
+Use the diff constantly to police scope:
+
+```bash
+git diff --stat
+git diff --name-only
+git diff
+```
+
+Remove unrelated edits before committing. Do not bundle cleanup, formatting churn, renames, refactors, dependency upgrades, or opportunistic fixes with the requested change.
+
+## Preserve existing behavior
+
+Follow existing project patterns. Avoid speculative architecture or future-proofing unless the issue explicitly calls for it.
+
+Get explicit human approval before changing:
+
+- database schemas or generated Drizzle migrations
+- dependencies
+- environment variables
+- authentication, authorization, payments, email, uploads, or deployment behavior
+- repo-wide tooling, lint, formatter, or CI settings
+
+Never commit secrets, `.env` files, tokens, credentials, private keys, production data, or sensitive generated artifacts.
+
+## Required checks before committing
+
+Before any commit, run from the repo root:
+
+```bash
+pnpm format
+pnpm lint
+pnpm typecheck
+```
+
+If relevant, also run targeted checks such as:
+
+```bash
+pnpm build
+pnpm --filter=@forge/blade typecheck
+pnpm --filter=@forge/club typecheck
+pnpm db:generate
+pnpm db:migrate
+```
+
+Do not claim a check passed unless it actually ran and passed. If blocked, report the exact command and error.
+
+## Commit and PR hygiene
+
+Follow `docs/GITHUB-ETIQUETTE.md` for branch names, commits, PR titles, labels, and issue references.
+
+If auto-committing AI-assisted work, include an LLM co-author trailer:
+
+```text
+Co-authored-by: Codex <codex@openai.com>
+Co-authored-by: Claude <claude@anthropic.com>
+```
+
+Use the accurate tool/model name when different.
+
+Agent-assisted PRs should summarize:
+
+- what changed
+- what scoped the work
+- checks run and results
+- screenshots/video for UI changes
+- assumptions, limitations, or follow-up work
+
+## Communication expectations
+
+Be explicit about uncertainty. Ask technical questions early instead of guessing. Encourage discussion when multiple reasonable approaches exist, especially for shared packages, schema design, permissions, or UX behavior.
+
+Final updates should include files changed, key decisions, checks run, and anything intentionally left out of scope.
+
+## Hard rules
+
+Do not:
+
+- fabricate test results, screenshots, logs, or command output
+- mark PR checklist items as complete unless true
+- bypass type or lint errors with `any`, broad casts, `eslint-disable`, or ignored promises unless justified
+- edit unrelated apps/packages to make a change appear to work
+- delete or rewrite migrations casually
+- commit secrets or local-only config
+- leave debug logging, dead code, or commented-out experiments behind

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,11 @@ Read the relevant project context first:
 - `CONTRIBUTING.md`
 - `docs/GETTING-STARTED.md`
 - `docs/GITHUB-ETIQUETTE.md`
+- `docs/REPO-CONVENTIONS.md` for Blade and `packages/*` placement/boundary rules
+- `docs/DATABASE-USAGE.md` before changing DB schemas, DB queries, or table semantics
 - Any task-relevant files in `docs/`
 
-Search for existing patterns before adding new helpers, components, dependencies, routes, schema fields, or workflows.
+Search for existing patterns before adding new helpers, components, dependencies, routes, schema fields, or workflows. Follow `docs/REPO-CONVENTIONS.md` when deciding where constants, utilities, tRPC routers, DB code, and UI components belong. Follow `docs/DATABASE-USAGE.md` when deciding what a table or ambiguous column represents.
 
 ## Reverse-prompt and branch first
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/DATABASE-USAGE.md
+++ b/docs/DATABASE-USAGE.md
@@ -1,0 +1,120 @@
+# Database Usage
+
+This is a practical map of Forge's Drizzle tables: what each table is for, how app code currently uses it, and notable field semantics agents should preserve before editing schema or queries.
+
+Schemas live in:
+
+- `packages/db/src/schemas/auth.ts` for auth/roles/session tables.
+- `packages/db/src/schemas/knight-hacks.ts` for Knight Hacks product tables.
+
+## Auth, roles, and sessions
+
+| Table export    | SQL table            | Usage                                                                                                                                                                            |
+| --------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `User`          | `auth_user`          | Better Auth creates Discord OAuth users here, and app code uses the row for Discord guild joins, role/permission management, issue assignees, user lists, and bot point lookups. |
+| `Account`       | `auth_account`       | Better Auth stores provider credentials here, and Discord utilities read the latest Discord account token/scope when joining users to the Knight Hacks server.                   |
+| `Session`       | `auth_session`       | Better Auth owns normal Blade login sessions here, with explicit deletion when member/hacker delete flows need to log the user out.                                              |
+| `JudgeSession`  | `auth_judge_session` | Hackathon judge magic links create room-scoped judge sessions that are validated from a judge cookie and counted/deleted by room in the judge router.                            |
+| `Verifications` | `auth_verification`  | Better Auth's adapter uses this verification table; no direct app reads/writes were found outside auth configuration and migrations.                                             |
+| `Roles`         | `auth_roles`         | Stores Discord-linked Blade roles, permission bitstrings, issue reminder metadata, and team display colors for permissions, role sync, forms, issues, and reminders.             |
+| `Permissions`   | `auth_permissions`   | User-to-role join table used for Blade authorization, Discord role sync, manual/batch role grants, issue assignee validation, and permission checks.                             |
+
+Notes:
+
+- `User.discordUserId` is the Discord identity field, but it is not schema-unique.
+- `User.name` is treated as the Discord username in bot code.
+- `Account` has a compound primary key of `(provider, providerAccountId)`; `id` is not the primary key.
+- `Roles.permissions` is a raw varchar bitstring interpreted against `PERMISSIONS.PERMISSIONS`.
+- `Permissions` has no schema-level unique constraint on `(userId, roleId)`; code tries to avoid duplicates.
+- `JudgeSession.sessionToken` is separate from Better Auth sessions even though the naming overlaps.
+
+## Club membership, dues, and events
+
+| Table export     | SQL table                     | Usage                                                                                                                                                                                     |
+| ---------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Member`         | `knight_hacks_member`         | Stores Blade club member profiles used for signup/profile updates, admin search/filtering, guild profiles, resumes, dues, event check-in, attendance, alumni roles, and bot leaderboards. |
+| `DuesPayment`    | `knight_hacks_dues_payment`   | Records yearly dues payments from Stripe/admin flows and gates dues-only event check-in and dues-paying member queries.                                                                   |
+| `OtherCompanies` | `knight_hacks_companies`      | Stores custom company names entered during member create/update when they are not in the constants list.                                                                                  |
+| `Event`          | `knight_hacks_event`          | Stores club and hackathon events synchronized with Discord/Google Calendar and used for listings, reminders, forms, feedback, issues, check-in, and attendance.                           |
+| `EventAttendee`  | `knight_hacks_event_attendee` | Records club member check-ins to events for attendee lists, attendance counts, member event history, and point awards.                                                                    |
+| `EventFeedback`  | `knight_hacks_event_feedback` | Legacy/unused feedback table; current feedback flows appear to use dynamic `FormsSchemas` and `FormResponse` records instead.                                                             |
+
+Notes:
+
+- `Member.discordUser` stores `ctx.session.user.name`, not the numeric Discord user ID.
+- `Member.phoneNumber` is nullable but unique.
+- `DuesPayment` is unique per `(memberId, year)`.
+- `Event.roles` is a string array used by reminders and role-scoped event filtering.
+- `Event.start_datetime`/`end_datetime` are sometimes adjusted in create/update flows; preserve existing timezone/date behavior unless the task is explicitly to change it.
+- `EventAttendee` has no schema-level unique constraint on `(memberId, eventId)`; duplicate prevention lives in check-in code.
+
+## Hackathons, hackers, and judging
+
+| Table export          | SQL table                            | Usage                                                                                                                                                                   |
+| --------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Hackathon`           | `knight_hacks_hackathon`             | Central hackathon config used for application routing, current/upcoming/past selection, admin editing, event association, email/background assets, and judging context. |
+| `Hacker`              | `knight_hacks_hacker`                | Stores reusable person-level hacker profile/application data used by dashboards, admin hacker lists, filtering, check-in lookup, updates, and emails.                   |
+| `HackerAttendee`      | `knight_hacks_hacker_attendee`       | Per-hackathon join table for a hacker's application status, confirmation time, points, and assigned class.                                                              |
+| `HackerEventAttendee` | `knight_hacks_hacker_event_attendee` | Records hackathon event check-ins and powers duplicate check-in prevention, attendance counts, attendee lists, and point awards.                                        |
+| `Sponsor`             | `knight_hacks_sponsor`               | Reserved for sponsor metadata; current sponsor displays elsewhere are static or unrelated.                                                                              |
+| `HackathonSponsor`    | `knight_hacks_hackathon_sponsor`     | Reserved hackathon-to-sponsor tier join table.                                                                                                                          |
+| `Challenges`          | `knight_hacks_challenges`            | Stores Devpost opt-in prize challenges plus general challenges, then feeds room assignment, judge assignment, judging filters, submissions, and results.                |
+| `Teams`               | `knight_hacks_teams`                 | Stores Devpost CSV project/team metadata used for judging project names, Devpost links, descriptions, universities, emails, and results.                                |
+| `Submissions`         | `knight_hacks_submissions`           | Join table for a team's submission to a challenge within a hackathon, used by judge project lists and result aggregation.                                               |
+| `Judges`              | `knight_hacks_judges`                | Stores judge name, room, and challenge assignment for judge session flows, project filtering, QR/session management, and rubric attribution.                            |
+| `JudgedSubmission`    | `knight_hacks_judged_submission`     | Stores one judge's rubric ratings and feedback for a submission, used for duplicate prevention, metrics, result tables, and detailed judging views.                     |
+
+Notes:
+
+- `Hackathon.name` is the unique slug/lookup key used in routes and API inputs; `Hackathon.displayName` is the human-facing label for dashboards, admin UI, emails, selectors, and logs.
+- Do not use `Hackathon.name` and `Hackathon.displayName` interchangeably: use `name` for stable identifiers and `displayName` for user-facing copy.
+- Hackathon date semantics vary by query: "current" can mean applications open, not ended, or future-start depending on the router.
+- `Hacker.dateCreated`/`timeCreated` describe profile creation; per-hackathon application timing lives on `HackerAttendee.timeApplied`/`timeConfirmed`.
+- `HackerAttendee.status` is the application/attendance state; keep values aligned with `FORMS.HACKATHON_APPLICATION_STATES`.
+- `HackerAttendee.class` is a nullable game/team class assigned during check-in, not original application profile data.
+- `HackerEventAttendee.hackathonId` duplicates context derivable through `eventId` and `hackerAttId`; no DB-level consistency check was found.
+- `Challenges.sponsor` is plain text and is not linked to `Sponsor`.
+- `Teams.matchKey` is globally unique and derived from Devpost submitter name, created timestamp, and project title, not scoped by hackathon.
+- `Teams.submissionUrl` and `Teams.devpostUrl` are both Devpost CSV URL fields in current import flows.
+- `Submissions.hackathonId` duplicates hackathon context from `teamId` and `challengeId`; app code filters by it, but schema consistency is not enforced.
+- `Judges` has no direct `hackathonId`; hackathon scope is inferred through `challengeId`.
+- `JudgedSubmission` has no schema-level unique constraint on `(submissionId, judgeId)` and no rating range constraints; code handles duplicate prevention and validation.
+
+## Dynamic forms
+
+| Table export         | SQL table                           | Usage                                                                                                                                                             |
+| -------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FormSections`       | `knight_hacks_form_sections`        | Stores named/orderable form sections used to organize forms and drive section-level access/editing in the form editor.                                            |
+| `FormSectionRoles`   | `knight_hacks_form_section_roles`   | Section-to-role join table controlling which roles can access/edit a form section; an empty role list means broadly accessible.                                   |
+| `FormsSchemas`       | `knight_hacks_form_schemas`         | Stores dynamic form definitions, JSON form data, validators, slugs, section metadata, closed/edit/resubmission flags, and dues-only behavior.                     |
+| `FormResponseRoles`  | `knight_hacks_form_response_roles`  | Form-to-role join table controlling who may submit/respond to a form, despite the name sounding like response-reading permissions.                                |
+| `FormResponse`       | `knight_hacks_form_response`        | Stores each user's JSON form submission and timestamps for create/edit/delete, admin response views, dashboards, event feedback, and duplicate-submission checks. |
+| `TrpcFormConnection` | `knight_hacks_trpc_form_connection` | Stores dynamic callback mappings from a form to a tRPC procedure, with string procedure names and JSON field mappings executed after submission.                  |
+
+Notes:
+
+- `FormsSchemas` has both `section` string and nullable `sectionId`; code still filters/counts by string while access checks prefer `sectionId` with fallback lookup by name.
+- `FormsSchemas.slugName` is the unique route/API identifier for forms.
+- `FormResponse.form` does not cascade at the schema level, so delete flows manually remove responses before forms.
+- `TrpcFormConnection.connections` is untyped `jsonb`, and form deletion does not appear to delete related connection rows.
+
+## Issues and templates
+
+| Table export              | SQL table                                 | Usage                                                                                                                               |
+| ------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `Issue`                   | `knight_hacks_issue`                      | Main task/issue table used for CRUD, hierarchy, filtering, calendar/reminders, visibility enforcement, and assignee/team workflows. |
+| `IssuesToTeamsVisibility` | `knight_hacks_issues_to_teams_visibility` | Issue-to-role/team visibility join table used to let additional teams see/manage issues beyond the owning `Issue.team`.             |
+| `IssuesToUsersAssignment` | `knight_hacks_issues_to_users_assignment` | Issue-to-user assignment join table used for assignee filters, UI relations, cron reminders, and team membership validation.        |
+| `Template`                | `knight_hacks_template`                   | Stores issue templates used by the issue-template API/UI and expanded by Blade's issue creation dialog into parent/child issues.    |
+
+Notes:
+
+- `Issue.team` references `Roles.id`; in issue code, "team" usually means a role/team row, not a hackathon team project.
+- `Issue.parent` is a nullable self-reference with `onDelete: set null`, but delete code may still manually delete subtrees.
+- `IssuesToTeamsVisibility` also stores the issue's own team via `ensureTeamVisible`, duplicating visibility already implied by `Issue.team`.
+- `IssuesToUsersAssignment` assignments are validated in code to ensure users belong to the issue team.
+- `Template.body` is generic `jsonb` in the DB, but the API validates it as an array of nested issue template nodes.
+
+## Undocumented columns
+
+If a task needs a table or column not explained here, inspect existing usage first. If the intended semantics are still not clear from code, ask a clarifying question before setting a new precedent.

--- a/docs/REPO-CONVENTIONS.md
+++ b/docs/REPO-CONVENTIONS.md
@@ -1,0 +1,101 @@
+# Forge Repo Conventions
+
+These conventions document the structure agents should preserve when editing Forge. Prefer existing patterns, keep changes scoped, and treat existing boundary violations as debt to avoid copying.
+
+## Blade (`apps/blade`)
+
+- Keep `app/**/page.tsx` thin: auth, permission checks, redirects, initial server tRPC reads, and rendering route components only.
+- Put Blade UI in `apps/blade/src/app/_components/**`, grouped by feature. Use `_components/shared` only for Blade-wide reusable pieces.
+- Do not put Blade-specific product components in `@forge/ui`; `@forge/ui` is for app-agnostic primitives.
+- Server components/pages use `~/trpc/server` (`api`, `HydrateClient`). Client components use `~/trpc/react`.
+- Do not add `"use client"` to pages just to use hooks. Keep auth/permissions server-side and move interactivity into a client component.
+- Blade-only constants belong in `apps/blade/src/consts`. Constants used across apps/packages belong in `@forge/consts`.
+- Blade-only helpers belong near the feature or in `apps/blade/src/lib`. Shared helpers belong in `@forge/utils`.
+
+## Constants
+
+Use this placement hierarchy:
+
+| Scope                  | Location                                    |
+| ---------------------- | ------------------------------------------- |
+| One component/file     | local `const` near use                      |
+| Multiple Blade files   | `apps/blade/src/consts`                     |
+| Multiple apps/packages | `packages/consts/src/*` via `@forge/consts` |
+
+`@forge/consts` owns shared literals, option lists, enum sources, Discord IDs, MinIO bucket names, issue statuses, event tags, permission names, and similar metadata. Export new namespaces from `packages/consts/src/index.ts`.
+
+Do not duplicate constants that already exist in `@forge/consts`. Existing cross-package relative imports in const files are debt, not a pattern to copy.
+
+## Utilities
+
+Use this placement hierarchy:
+
+| Scope                   | Location                                                  |
+| ----------------------- | --------------------------------------------------------- |
+| One feature             | feature-local helper file                                 |
+| Multiple Blade features | `apps/blade/src/lib` or feature `_components/**/utils.ts` |
+| Multiple apps/packages  | `packages/utils/src/*` via `@forge/utils`                 |
+
+`@forge/utils` owns reusable non-UI behavior: date/time helpers, permission calculations, form transforms, CSV/export logic, recursive tree helpers, status filtering/counting, and integration helpers.
+
+Constants do not belong in utils. Server-only utilities must stay behind explicit server-only files/subpath exports such as `@forge/utils/permissions.server`; do not leak DB, cookie, or service-client code through the root barrel.
+
+## tRPC and API (`packages/api`)
+
+- Routers live in `packages/api/src/routers/*` and are registered in `packages/api/src/root.ts`.
+- Child routers should export named router records ending in `Router`, usually with `satisfies TRPCRouterRecord`.
+- When adding a router, update `root.ts`: import it, add it to the type map, and add it to the exported router object. The key becomes the client path, e.g. `api.forms.*`.
+- Use tRPC for normal app CRUD/workflows. Do not add REST route handlers unless the task specifically needs an external webhook, callback, file endpoint, or protocol boundary.
+- Choose procedures intentionally:
+  - `publicProcedure`: truly public operations.
+  - `protectedProcedure`: logged-in user operations.
+  - `permProcedure`: permission-aware admin operations.
+  - `judgeProcedure`: only for established judge flows.
+- `permProcedure` loads permissions but does not choose the required permission. Call `permissions.controlPerms.or(...)` or `.and(...)` near the top of the resolver.
+- Keep API-side business workflows in `@forge/api`; do not move them into `@forge/db` or UI code.
+
+## Database (`packages/db`)
+
+- `@forge/db` owns Drizzle schemas, relations, schema types, the DB client, and Drizzle helper exports.
+- Read `docs/DATABASE-USAGE.md` before changing table semantics, adding queries against unfamiliar tables, or deciding between ambiguous columns.
+- Import the client from `@forge/db/client`; import schemas from `@forge/db/schemas/*`; import Drizzle helpers from `@forge/db`.
+- DB schemas may consume enum/value sources from `@forge/consts`.
+- Use `db.transaction(...)` for multi-table state changes.
+- Do not put business workflows, auth checks, Discord calls, email sends, uploads, or tRPC procedures in `@forge/db`.
+
+## Package boundaries
+
+| Package             | Owns                                                                   | Must not own                                    |
+| ------------------- | ---------------------------------------------------------------------- | ----------------------------------------------- |
+| `@forge/consts`     | Shared constants, option lists, enum sources, IDs, permission metadata | DB/API/auth/UI logic                            |
+| `@forge/validators` | Shared Zod schemas and pure validation helpers                         | DB/API/auth/UI logic                            |
+| `@forge/db`         | Drizzle schemas, relations, DB client, schema types                    | Business workflows or service integrations      |
+| `@forge/auth`       | Better Auth setup, session/token helpers                               | App UI or feature workflows                     |
+| `@forge/api`        | tRPC routers, procedures, API-side workflows                           | App components or DB schema ownership           |
+| `@forge/utils`      | Reusable non-UI helpers and integrations                               | Shared constants or UI components               |
+| `@forge/ui`         | App-agnostic UI primitives                                             | Blade-specific UI, DB/auth/API/server-only deps |
+| `@forge/email`      | Email clients, send functions, templates                               | General app workflows                           |
+
+Never import another package through relative internals like `../../utils/src/...` or `../../../db/src/...`. Use package exports or fix the package boundary. Existing internal relative imports are debt, not precedent.
+
+## UI package (`packages/ui`)
+
+- Use `@forge/ui` for reusable primitives only.
+- Prefer subpath imports such as `@forge/ui/button`, `@forge/ui/dialog`, plus `cn` from `@forge/ui`.
+- Keep composed/domain UI in apps, especially `apps/blade/src/app/_components`.
+- Do not add DB, auth, API, email, or server-only utility dependencies to `@forge/ui`.
+
+## Common anti-patterns
+
+Do not:
+
+- add constants inside components when they belong in `~/consts` or `@forge/consts`;
+- duplicate constants, status maps, dropdown options, or permission metadata;
+- leave reusable logic buried in pages/components;
+- add `"use client"` to a page instead of extracting a client component;
+- create REST endpoints for ordinary app CRUD instead of tRPC;
+- add a tRPC router without registering it in `packages/api/src/root.ts`;
+- use `permProcedure` without an explicit permission check;
+- put app-specific components in `@forge/ui`;
+- import across package internals with relative paths;
+- copy existing debt patterns unless the task is explicitly to clean them up.


### PR DESCRIPTION
## What changed
- Added `docs/REPO-CONVENTIONS.md` with compact Blade, packages/*, constants, utils, tRPC, DB, and UI placement rules.
- Added `docs/DATABASE-USAGE.md` with one-sentence usage notes for every exported DB table and documented semantics for important columns.
- Updated `AGENTS.md` so coding agents read both docs before changing repo structure, DB queries, or table semantics.

## Why
Forge needs explicit conventions for agent-assisted work so future changes keep constants, utilities, routers, DB logic, and UI components in the right place instead of copying inconsistent patterns.

## How to test
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm build` — blocked locally by missing required environment variables (`BLADE_URL`, Blade Stripe/MinIO/pass credentials, auth secret, Google credentials, etc.); non-env-dependent build tasks completed before Next app env validation failed.

## Screenshots
N/A — documentation-only change.

Closes #467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive database usage guide mapping all Drizzle tables, their purposes, and field semantics
  * Added repository conventions documentation covering code organization, package boundaries, and development best practices
  * Added AI agent behavior guidelines for development workflow

* **Chores**
  * Enhanced Cursor IDE configuration for development environment consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->