### PR TITLE
Optimize club site loading and scroll performance

### DIFF
--- a/apps/club/src/app/_components/club-content-page.tsx
+++ b/apps/club/src/app/_components/club-content-page.tsx
@@ -69,7 +69,9 @@ function ContentButton({ href, label, variant = "gold" }: ContentLink) {
           {content}
         </a>
       ) : (
-        <Link href={href}>{content}</Link>
+        <Link href={href} prefetch={false}>
+          {content}
+        </Link>
       )}
     </Button>
   );

--- a/apps/club/src/app/_components/club-motion-runtime.tsx
+++ b/apps/club/src/app/_components/club-motion-runtime.tsx
@@ -9,6 +9,26 @@ const HISTORY_TIMELINE_SELECTOR = "[data-history-timeline]";
 const HISTORY_MARKER_SELECTOR = "[data-history-marker]";
 const TILT_SELECTOR = "[data-tilt]";
 
+interface DriftState {
+  element: HTMLElement;
+  documentTop: number;
+  height: number;
+  depth: number;
+}
+
+interface HeroState {
+  element: HTMLElement;
+  documentTop: number;
+  height: number;
+}
+
+interface TimelineState {
+  element: HTMLElement;
+  markers: HTMLElement[];
+  documentTop: number;
+  height: number;
+}
+
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
@@ -26,6 +46,58 @@ export default function ClubMotionRuntime() {
 
     const observedElements = new WeakSet<Element>();
     const revealElements = new Set<Element>();
+    let driftElements: DriftState[] = [];
+    let heroElements: HeroState[] = [];
+    let timelines: TimelineState[] = [];
+    let scrollableHeight = 0;
+
+    function getDocumentTop(element: HTMLElement) {
+      let documentTop = 0;
+      let offsetElement: HTMLElement | null = element;
+
+      while (offsetElement) {
+        documentTop += offsetElement.offsetTop;
+        offsetElement = offsetElement.offsetParent as HTMLElement | null;
+      }
+
+      return documentTop;
+    }
+
+    function refreshDocumentMetrics() {
+      scrollableHeight = Math.max(
+        document.documentElement.scrollHeight - window.innerHeight,
+        0,
+      );
+    }
+
+    function refreshScrollTargets() {
+      refreshDocumentMetrics();
+      driftElements = Array.from(
+        document.querySelectorAll<HTMLElement>(DRIFT_SELECTOR),
+      ).map((element) => ({
+        element,
+        documentTop: getDocumentTop(element),
+        height: Math.max(element.offsetHeight, 1),
+        depth: Number(element.dataset.scrollDrift ?? 12),
+      }));
+      heroElements = Array.from(
+        document.querySelectorAll<HTMLElement>(HERO_SELECTOR),
+      ).map((element) => ({
+        element,
+        documentTop: getDocumentTop(element),
+        height: Math.max(element.offsetHeight, 1),
+      }));
+      timelines = Array.from(
+        document.querySelectorAll<HTMLElement>(HISTORY_TIMELINE_SELECTOR),
+      ).map((timeline) => ({
+        element: timeline,
+        markers: Array.from(
+          timeline.querySelectorAll<HTMLElement>(HISTORY_MARKER_SELECTOR),
+        ),
+        documentTop: getDocumentTop(timeline),
+        height: Math.max(timeline.offsetHeight, 1),
+      }));
+    }
 
     function revealElement(element: Element) {
       element.classList.add("is-visible");
@@ -47,12 +119,6 @@ export default function ClubMotionRuntime() {
       },
     );
 
-    function isInsideRevealRange(element: Element) {
-      const rect = element.getBoundingClientRect();
-
-      return rect.top < window.innerHeight * 1.05 && rect.bottom > 0;
-    }
-
     function observeElement(element: Element) {
       if (observedElements.has(element)) return;
 
@@ -60,20 +126,7 @@ export default function ClubMotionRuntime() {
       element.classList.add("is-motion-observed");
       revealElements.add(element);
 
-      if (isInsideRevealRange(element)) {
-        revealElement(element);
-        return;
-      }
-
       revealObserver.observe(element);
-    }
-
-    function revealVisibleElements() {
-      for (const element of [...revealElements]) {
-        if (isInsideRevealRange(element)) {
-          revealElement(element);
-        }
-      }
     }
 
     function observeTree(rootNode: ParentNode) {
@@ -87,18 +140,29 @@ export default function ClubMotionRuntime() {
     }
 
     observeTree(document);
+    refreshScrollTargets();
     root.dataset.motion = "ready";
+    const hasTiltTargets = document.querySelector(TILT_SELECTOR) !== null;
 
     const mutationObserver = new MutationObserver((mutations) => {
+      let shouldRefreshScrollTargets = false;
+
       for (const mutation of mutations) {
+        if (mutation.removedNodes.length > 0) {
+          shouldRefreshScrollTargets = true;
+        }
+
         for (const node of mutation.addedNodes) {
           if (node instanceof Element) {
             observeTree(node);
+            shouldRefreshScrollTargets = true;
           }
         }
       }
 
-      revealVisibleElements();
+      if (shouldRefreshScrollTargets) {
+        refreshScrollTargets();
+      }
     });
 
     mutationObserver.observe(document.body, {
@@ -110,10 +174,7 @@ export default function ClubMotionRuntime() {
 
     function updateScrollMotion() {
       scrollFrameId = null;
-      revealVisibleElements();
 
-      const scrollableHeight =
-        document.documentElement.scrollHeight - window.innerHeight;
       const scrollProgress =
         scrollableHeight > 0 ? window.scrollY / scrollableHeight : 1;
 
@@ -123,74 +184,87 @@ export default function ClubMotionRuntime() {
       );
 
       const viewportCenter = window.innerHeight / 2;
+      const scrollY = window.scrollY;
 
-      document
-        .querySelectorAll<HTMLElement>(DRIFT_SELECTOR)
-        .forEach((element) => {
-          const rect = element.getBoundingClientRect();
-          const elementCenter = rect.top + rect.height / 2;
-          const depth = Number(element.dataset.scrollDrift ?? 12);
-          const normalizedDistance = clamp(
-            (viewportCenter - elementCenter) / viewportCenter,
-            -1,
-            1,
+      for (const drift of driftElements) {
+        const top = drift.documentTop - scrollY;
+        const bottom = top + drift.height;
+
+        if (bottom < -200 || top > window.innerHeight + 200) {
+          continue;
+        }
+
+        const elementCenter = top + drift.height / 2;
+        const normalizedDistance = clamp(
+          (viewportCenter - elementCenter) / viewportCenter,
+          -1,
+          1,
+        );
+
+        drift.element.style.setProperty(
+          "--club-scroll-drift",
+          `${(normalizedDistance * drift.depth).toFixed(2)}px`,
+        );
+      }
+
+      for (const hero of heroElements) {
+        const top = hero.documentTop - scrollY;
+        const bottom = top + hero.height;
+
+        if (bottom < 0 || top > window.innerHeight) {
+          continue;
+        }
+
+        const heroProgress = clamp(-top / hero.height, 0, 1);
+
+        hero.element.style.setProperty(
+          "--club-hero-progress",
+          heroProgress.toFixed(3),
+        );
+      }
+
+      for (const timeline of timelines) {
+        const viewportAnchor = window.innerHeight * 0.5;
+        const viewportAnchorDocument = scrollY + viewportAnchor;
+
+        if (
+          viewportAnchorDocument < timeline.documentTop - window.innerHeight ||
+          viewportAnchorDocument >
+            timeline.documentTop + timeline.height + window.innerHeight
+        ) {
+          continue;
+        }
+
+        const progressY = clamp(
+          viewportAnchorDocument - timeline.documentTop,
+          0,
+          timeline.height,
+        );
+        const scrubberY = clamp(
+          progressY,
+          21,
+          Math.max(timeline.height - 21, 21),
+        );
+        const timelineProgress = progressY / timeline.height;
+
+        timeline.element.style.setProperty(
+          "--history-timeline-progress",
+          timelineProgress.toFixed(4),
+        );
+        timeline.element.style.setProperty(
+          "--history-timeline-scrubber-y",
+          `${scrubberY.toFixed(2)}px`,
+        );
+
+        for (const marker of timeline.markers) {
+          const markerProgress = Number(marker.dataset.historyMarker ?? 0);
+
+          marker.classList.toggle(
+            "is-history-marker-active",
+            timelineProgress + 0.018 >= markerProgress,
           );
-
-          element.style.setProperty(
-            "--club-scroll-drift",
-            `${(normalizedDistance * depth).toFixed(2)}px`,
-          );
-        });
-
-      document.querySelectorAll<HTMLElement>(HERO_SELECTOR).forEach((hero) => {
-        const rect = hero.getBoundingClientRect();
-        const heroHeight = Math.max(rect.height, 1);
-        const heroProgress = clamp(-rect.top / heroHeight, 0, 1);
-
-        hero.style.setProperty("--club-hero-progress", heroProgress.toFixed(3));
-      });
-
-      document
-        .querySelectorAll<HTMLElement>(HISTORY_TIMELINE_SELECTOR)
-        .forEach((timeline) => {
-          const viewportAnchor = window.innerHeight * 0.5;
-          const timelineHeight = Math.max(timeline.offsetHeight, 1);
-          const viewportAnchorDocument = window.scrollY + viewportAnchor;
-          let timelineDocumentTop = 0;
-          let offsetElement: HTMLElement | null = timeline;
-
-          while (offsetElement) {
-            timelineDocumentTop += offsetElement.offsetTop;
-            offsetElement = offsetElement.offsetParent as HTMLElement | null;
-          }
-
-          const scrubberY = clamp(
-            viewportAnchorDocument - timelineDocumentTop,
-            0,
-            timelineHeight,
-          );
-          const timelineProgress = scrubberY / timelineHeight;
-
-          timeline.style.setProperty(
-            "--history-timeline-progress",
-            timelineProgress.toFixed(4),
-          );
-          timeline.style.setProperty(
-            "--history-timeline-scrubber-y",
-            `${scrubberY.toFixed(2)}px`,
-          );
-
-          timeline
-            .querySelectorAll<HTMLElement>(HISTORY_MARKER_SELECTOR)
-            .forEach((marker) => {
-              const markerProgress = Number(marker.dataset.historyMarker ?? 0);
-
-              marker.classList.toggle(
-                "is-history-marker-active",
-                timelineProgress + 0.018 >= markerProgress,
-              );
-            });
-        });
+        }
+      }
     }
 
     function scheduleScrollMotion() {
@@ -257,20 +331,30 @@ export default function ClubMotionRuntime() {
     }
 
     window.addEventListener("scroll", scheduleScrollMotion, { passive: true });
-    window.addEventListener("resize", scheduleScrollMotion);
-    window.addEventListener("pointermove", handlePointerMove, {
-      passive: true,
-    });
-    window.addEventListener("pointerout", handlePointerOut);
+    function handleResize() {
+      refreshScrollTargets();
+      scheduleScrollMotion();
+    }
+
+    window.addEventListener("resize", handleResize);
+    if (hasTiltTargets) {
+      window.addEventListener("pointermove", handlePointerMove, {
+        passive: true,
+      });
+      window.addEventListener("pointerout", handlePointerOut);
+    }
     scheduleScrollMotion();
 
     return () => {
       revealObserver.disconnect();
       mutationObserver.disconnect();
       window.removeEventListener("scroll", scheduleScrollMotion);
-      window.removeEventListener("resize", scheduleScrollMotion);
-      window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerout", handlePointerOut);
+      window.removeEventListener("resize", handleResize);
+
+      if (hasTiltTargets) {
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerout", handlePointerOut);
+      }
 
       if (scrollFrameId !== null) {
         window.cancelAnimationFrame(scrollFrameId);

--- a/apps/club/src/app/_components/club-motion-runtime.tsx
+++ b/apps/club/src/app/_components/club-motion-runtime.tsx
@@ -7,7 +7,11 @@ const DRIFT_SELECTOR = "[data-scroll-drift]";
 const HERO_SELECTOR = "[data-hero]";
 const HISTORY_TIMELINE_SELECTOR = "[data-history-timeline]";
 const HISTORY_MARKER_SELECTOR = "[data-history-marker]";
+const HISTORY_SCRUBBER_SELECTOR = ".club-history-timeline-scrubber";
 const TILT_SELECTOR = "[data-tilt]";
+const DEFAULT_DRIFT_DEPTH_PX = 12;
+const DRIFT_OVERSCAN_VIEWPORT_RATIO = 0.25;
+const TIMELINE_VIEWPORT_ANCHOR_RATIO = 0.5;
 
 interface DriftState {
   element: HTMLElement;
@@ -27,6 +31,8 @@ interface TimelineState {
   markers: HTMLElement[];
   documentTop: number;
   height: number;
+  scrubberHalfHeight: number;
+  markerLeadProgress: number;
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -45,7 +51,6 @@ export default function ClubMotionRuntime() {
     }
 
     const observedElements = new WeakSet<Element>();
-    const revealElements = new Set<Element>();
     let driftElements: DriftState[] = [];
     let heroElements: HeroState[] = [];
     let timelines: TimelineState[] = [];
@@ -78,7 +83,7 @@ export default function ClubMotionRuntime() {
         element,
         documentTop: getDocumentTop(element),
         height: Math.max(element.offsetHeight, 1),
-        depth: Number(element.dataset.scrollDrift ?? 12),
+        depth: Number(element.dataset.scrollDrift ?? DEFAULT_DRIFT_DEPTH_PX),
       }));
       heroElements = Array.from(
         document.querySelectorAll<HTMLElement>(HERO_SELECTOR),
@@ -89,20 +94,29 @@ export default function ClubMotionRuntime() {
       }));
       timelines = Array.from(
         document.querySelectorAll<HTMLElement>(HISTORY_TIMELINE_SELECTOR),
-      ).map((timeline) => ({
-        element: timeline,
-        markers: Array.from(
-          timeline.querySelectorAll<HTMLElement>(HISTORY_MARKER_SELECTOR),
-        ),
-        documentTop: getDocumentTop(timeline),
-        height: Math.max(timeline.offsetHeight, 1),
-      }));
+      ).map((timeline) => {
+        const height = Math.max(timeline.offsetHeight, 1);
+        const scrubber = timeline.querySelector<HTMLElement>(
+          HISTORY_SCRUBBER_SELECTOR,
+        );
+        const scrubberHalfHeight = (scrubber?.offsetHeight ?? 0) / 2;
+
+        return {
+          element: timeline,
+          markers: Array.from(
+            timeline.querySelectorAll<HTMLElement>(HISTORY_MARKER_SELECTOR),
+          ),
+          documentTop: getDocumentTop(timeline),
+          height,
+          scrubberHalfHeight,
+          markerLeadProgress: scrubberHalfHeight / height,
+        };
+      });
     }
 
     function revealElement(element: Element) {
       element.classList.add("is-visible");
       revealObserver.unobserve(element);
-      revealElements.delete(element);
     }
 
     const revealObserver = new IntersectionObserver(
@@ -124,7 +138,6 @@ export default function ClubMotionRuntime() {
 
       observedElements.add(element);
       element.classList.add("is-motion-observed");
-      revealElements.add(element);
 
       revealObserver.observe(element);
     }
@@ -185,13 +198,17 @@ export default function ClubMotionRuntime() {
       );
 
       const viewportCenter = window.innerHeight / 2;
+      const driftOverscan = window.innerHeight * DRIFT_OVERSCAN_VIEWPORT_RATIO;
       const scrollY = window.scrollY;
 
       for (const drift of driftElements) {
         const top = drift.documentTop - scrollY;
         const bottom = top + drift.height;
 
-        if (bottom < -200 || top > window.innerHeight + 200) {
+        if (
+          bottom < -driftOverscan ||
+          top > window.innerHeight + driftOverscan
+        ) {
           continue;
         }
 
@@ -225,7 +242,8 @@ export default function ClubMotionRuntime() {
       }
 
       for (const timeline of timelines) {
-        const viewportAnchor = window.innerHeight * 0.5;
+        const viewportAnchor =
+          window.innerHeight * TIMELINE_VIEWPORT_ANCHOR_RATIO;
         const viewportAnchorDocument = scrollY + viewportAnchor;
 
         if (
@@ -243,8 +261,11 @@ export default function ClubMotionRuntime() {
         );
         const scrubberY = clamp(
           progressY,
-          21,
-          Math.max(timeline.height - 21, 21),
+          timeline.scrubberHalfHeight,
+          Math.max(
+            timeline.height - timeline.scrubberHalfHeight,
+            timeline.scrubberHalfHeight,
+          ),
         );
         const timelineProgress = progressY / timeline.height;
 
@@ -262,7 +283,7 @@ export default function ClubMotionRuntime() {
 
           marker.classList.toggle(
             "is-history-marker-active",
-            timelineProgress + 0.018 >= markerProgress,
+            timelineProgress + timeline.markerLeadProgress >= markerProgress,
           );
         }
       }

--- a/apps/club/src/app/_components/club-motion-runtime.tsx
+++ b/apps/club/src/app/_components/club-motion-runtime.tsx
@@ -142,7 +142,6 @@ export default function ClubMotionRuntime() {
     observeTree(document);
     refreshScrollTargets();
     root.dataset.motion = "ready";
-    const hasTiltTargets = document.querySelector(TILT_SELECTOR) !== null;
 
     const mutationObserver = new MutationObserver((mutations) => {
       let shouldRefreshScrollTargets = false;
@@ -162,6 +161,7 @@ export default function ClubMotionRuntime() {
 
       if (shouldRefreshScrollTargets) {
         refreshScrollTargets();
+        syncTiltListeners();
       }
     });
 
@@ -171,6 +171,7 @@ export default function ClubMotionRuntime() {
     });
 
     let scrollFrameId: number | null = null;
+    let resizeRefreshFrameId: number | null = null;
 
     function updateScrollMotion() {
       scrollFrameId = null;
@@ -273,7 +274,18 @@ export default function ClubMotionRuntime() {
       scrollFrameId = window.requestAnimationFrame(updateScrollMotion);
     }
 
+    function scheduleScrollTargetRefresh() {
+      if (resizeRefreshFrameId !== null) return;
+
+      resizeRefreshFrameId = window.requestAnimationFrame(() => {
+        resizeRefreshFrameId = null;
+        refreshScrollTargets();
+        scheduleScrollMotion();
+      });
+    }
+
     let tiltFrameId: number | null = null;
+    let tiltListenersAttached = false;
     let pendingTilt: {
       element: HTMLElement;
       x: number;
@@ -330,6 +342,38 @@ export default function ClubMotionRuntime() {
       target.style.removeProperty("--tilt-glow-y");
     }
 
+    function attachTiltListeners() {
+      if (tiltListenersAttached) return;
+
+      window.addEventListener("pointermove", handlePointerMove, {
+        passive: true,
+      });
+      window.addEventListener("pointerout", handlePointerOut);
+      tiltListenersAttached = true;
+    }
+
+    function detachTiltListeners() {
+      if (!tiltListenersAttached) return;
+
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerout", handlePointerOut);
+      tiltListenersAttached = false;
+      pendingTilt = null;
+
+      if (tiltFrameId !== null) {
+        window.cancelAnimationFrame(tiltFrameId);
+        tiltFrameId = null;
+      }
+    }
+
+    function syncTiltListeners() {
+      if (document.querySelector(TILT_SELECTOR)) {
+        attachTiltListeners();
+      } else {
+        detachTiltListeners();
+      }
+    }
+
     window.addEventListener("scroll", scheduleScrollMotion, { passive: true });
     function handleResize() {
       refreshScrollTargets();
@@ -337,31 +381,29 @@ export default function ClubMotionRuntime() {
     }
 
     window.addEventListener("resize", handleResize);
-    if (hasTiltTargets) {
-      window.addEventListener("pointermove", handlePointerMove, {
-        passive: true,
-      });
-      window.addEventListener("pointerout", handlePointerOut);
-    }
+    const resizeObserver =
+      "ResizeObserver" in window
+        ? new ResizeObserver(scheduleScrollTargetRefresh)
+        : null;
+    resizeObserver?.observe(document.documentElement);
+    resizeObserver?.observe(document.body);
+    syncTiltListeners();
     scheduleScrollMotion();
 
     return () => {
       revealObserver.disconnect();
       mutationObserver.disconnect();
+      resizeObserver?.disconnect();
       window.removeEventListener("scroll", scheduleScrollMotion);
       window.removeEventListener("resize", handleResize);
-
-      if (hasTiltTargets) {
-        window.removeEventListener("pointermove", handlePointerMove);
-        window.removeEventListener("pointerout", handlePointerOut);
-      }
+      detachTiltListeners();
 
       if (scrollFrameId !== null) {
         window.cancelAnimationFrame(scrollFrameId);
       }
 
-      if (tiltFrameId !== null) {
-        window.cancelAnimationFrame(tiltFrameId);
+      if (resizeRefreshFrameId !== null) {
+        window.cancelAnimationFrame(resizeRefreshFrameId);
       }
     };
   }, []);

--- a/apps/club/src/app/_components/footer.tsx
+++ b/apps/club/src/app/_components/footer.tsx
@@ -59,7 +59,11 @@ function FooterAnchor({
     );
   }
 
-  return <Link href={href}>{children}</Link>;
+  return (
+    <Link href={href} prefetch={false}>
+      {children}
+    </Link>
+  );
 }
 
 function FooterSocialLinks({
@@ -141,6 +145,7 @@ export default function Footer({ bladeUrl }: { bladeUrl: string }) {
                 <li key={link.href}>
                   <Link
                     href={link.href}
+                    prefetch={false}
                     className="transition-colors hover:text-white"
                   >
                     {link.label}

--- a/apps/club/src/app/_components/home-community-carousel.tsx
+++ b/apps/club/src/app/_components/home-community-carousel.tsx
@@ -93,7 +93,6 @@ function Polaroid({ slide }: { slide: CommunitySlide }) {
             src={slide.image}
             alt={slide.imageAlt}
             fill
-            priority
             sizes="(min-width: 1024px) 27rem, (min-width: 768px) 42vw, 84vw"
             className="object-cover grayscale transition duration-300"
             style={{ objectPosition: slide.imagePosition ?? "center" }}

--- a/apps/club/src/app/_components/home-events.tsx
+++ b/apps/club/src/app/_components/home-events.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 
@@ -95,11 +95,45 @@ export function HomeEvents({
   bladeUrl: string;
   eventLimit?: number;
 }) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const [events, setEvents] = useState<PublicClubEvent[]>([]);
   const [status, setStatus] = useState<EventsStatus>("loading");
+  const [shouldLoadEvents, setShouldLoadEvents] = useState(false);
   const safeEventLimit = getSafeEventLimit(eventLimit);
 
   useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container || shouldLoadEvents) return;
+
+    if (!("IntersectionObserver" in window)) {
+      const fallbackId = globalThis.setTimeout(() => {
+        setShouldLoadEvents(true);
+      }, 0);
+
+      return () => globalThis.clearTimeout(fallbackId);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+
+        setShouldLoadEvents(true);
+        observer.disconnect();
+      },
+      {
+        rootMargin: "700px 0px",
+      },
+    );
+
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, [shouldLoadEvents]);
+
+  useEffect(() => {
+    if (!shouldLoadEvents) return;
+
     const abortController = new AbortController();
 
     async function loadEvents() {
@@ -125,7 +159,7 @@ export function HomeEvents({
     void loadEvents();
 
     return () => abortController.abort();
-  }, [bladeUrl, safeEventLimit]);
+  }, [bladeUrl, safeEventLimit, shouldLoadEvents]);
 
   const homeEvents = useMemo(
     () => events.slice(0, safeEventLimit),
@@ -133,7 +167,7 @@ export function HomeEvents({
   );
 
   return (
-    <>
+    <div ref={containerRef}>
       {status === "loading" ? (
         <LoadingRows eventLimit={safeEventLimit} />
       ) : homeEvents.length > 0 ? (
@@ -158,12 +192,12 @@ export function HomeEvents({
           size="lg"
           className="club-button bg-white text-black shadow-[4px_4px_0_var(--club-gold)]"
         >
-          <Link href={allEventsHref}>
+          <Link href={allEventsHref} prefetch={false}>
             {allEventsLabel}
             <ExternalArrow />
           </Link>
         </Button>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/club/src/app/_components/home-events.tsx
+++ b/apps/club/src/app/_components/home-events.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 
@@ -12,8 +12,10 @@ import {
   formatEventTime,
   loadClubEvents,
 } from "../_lib/club-events";
+import { useDeferredSectionLoad } from "./use-deferred-section-load";
 
 const HOME_EVENT_LIMIT = 3;
+const HOME_EVENTS_LOAD_AHEAD_VIEWPORTS = 0.875;
 
 function ExternalArrow() {
   return <ArrowUpRight aria-hidden="true" className="ml-2 size-4" />;
@@ -95,41 +97,13 @@ export function HomeEvents({
   bladeUrl: string;
   eventLimit?: number;
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const { ref: containerRef, shouldLoad: shouldLoadEvents } =
+    useDeferredSectionLoad<HTMLDivElement>({
+      leadViewports: HOME_EVENTS_LOAD_AHEAD_VIEWPORTS,
+    });
   const [events, setEvents] = useState<PublicClubEvent[]>([]);
   const [status, setStatus] = useState<EventsStatus>("loading");
-  const [shouldLoadEvents, setShouldLoadEvents] = useState(false);
   const safeEventLimit = getSafeEventLimit(eventLimit);
-
-  useEffect(() => {
-    const container = containerRef.current;
-
-    if (!container || shouldLoadEvents) return;
-
-    if (!("IntersectionObserver" in window)) {
-      const fallbackId = globalThis.setTimeout(() => {
-        setShouldLoadEvents(true);
-      }, 0);
-
-      return () => globalThis.clearTimeout(fallbackId);
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry?.isIntersecting) return;
-
-        setShouldLoadEvents(true);
-        observer.disconnect();
-      },
-      {
-        rootMargin: "700px 0px",
-      },
-    );
-
-    observer.observe(container);
-
-    return () => observer.disconnect();
-  }, [shouldLoadEvents]);
 
   useEffect(() => {
     if (!shouldLoadEvents) return;

--- a/apps/club/src/app/_components/navbar.tsx
+++ b/apps/club/src/app/_components/navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { MotionStyle, MotionValue, Transition } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -11,7 +11,6 @@ import {
   useMotionValue,
   useMotionValueEvent,
   useReducedMotion,
-  useScroll,
   useSpring,
   useTransform,
 } from "framer-motion";
@@ -66,6 +65,7 @@ function NavLink({
   return (
     <Link
       href={item.href}
+      prefetch={false}
       aria-current={isActive ? "page" : undefined}
       className={cn("club-nav-link", isActive && "club-nav-link-active")}
       onClick={() => onSelect?.(item.href)}
@@ -124,8 +124,8 @@ export default function Navbar({ bladeUrl }: { bladeUrl: string }) {
   const pathname = usePathname();
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isClickDisabled, setIsClickDisabled] = useState(false);
+  const previousScrollY = useRef(0);
   const prefersReducedMotion = useReducedMotion();
-  const { scrollY } = useScroll();
   const rawNavFadeProgress = useMotionValue(0);
   const navFadeProgress = useSpring(
     rawNavFadeProgress,
@@ -164,21 +164,48 @@ export default function Navbar({ bladeUrl }: { bladeUrl: string }) {
     ? { duration: 0 }
     : { duration: 0.18, ease: "easeOut" };
 
-  useMotionValueEvent(scrollY, "change", (currentScrollY) => {
-    const previousScrollY = scrollY.getPrevious() ?? currentScrollY;
-    const scrollDelta = currentScrollY - previousScrollY;
+  useEffect(() => {
+    let animationFrameId: number | null = null;
 
-    if (currentScrollY <= 4 || scrollDelta < -1) {
-      rawNavFadeProgress.set(0);
-      return;
+    function updateNavFade() {
+      animationFrameId = null;
+      const currentScrollY = window.scrollY;
+      const scrollDelta = currentScrollY - previousScrollY.current;
+      previousScrollY.current = currentScrollY;
+
+      if (currentScrollY <= 4 || scrollDelta < -1) {
+        rawNavFadeProgress.set(0);
+        return;
+      }
+
+      if (scrollDelta > 1) {
+        rawNavFadeProgress.set(
+          Math.min(
+            1,
+            rawNavFadeProgress.get() + scrollDelta / NAV_FADE_DISTANCE,
+          ),
+        );
+      }
     }
 
-    if (scrollDelta > 1) {
-      rawNavFadeProgress.set(
-        Math.min(1, rawNavFadeProgress.get() + scrollDelta / NAV_FADE_DISTANCE),
-      );
+    function scheduleNavFade() {
+      if (animationFrameId !== null) return;
+
+      animationFrameId = window.requestAnimationFrame(updateNavFade);
     }
-  });
+
+    previousScrollY.current = window.scrollY;
+    scheduleNavFade();
+    window.addEventListener("scroll", scheduleNavFade, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", scheduleNavFade);
+
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [rawNavFadeProgress]);
 
   useMotionValueEvent(navOpacity, "change", (opacity) => {
     const shouldDisableClicks = opacity <= 0.5;
@@ -212,6 +239,7 @@ export default function Navbar({ bladeUrl }: { bladeUrl: string }) {
       <nav className="relative mx-auto flex h-20 w-full max-w-[1440px] items-center justify-between gap-4 px-5 md:px-8 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:gap-6 lg:px-8 xl:px-10">
         <Link
           href="/"
+          prefetch={false}
           className="flex shrink-0 items-center justify-self-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--club-gold)] lg:-ml-1 xl:-ml-2"
           aria-label="Knight Hacks home"
         >

--- a/apps/club/src/app/_components/navbar.tsx
+++ b/apps/club/src/app/_components/navbar.tsx
@@ -36,7 +36,9 @@ const ACTION_LINKS = [
 ] as const;
 
 const MOBILE_MENU_ID = "club-mobile-menu";
-const NAV_FADE_DISTANCE = 120;
+const NAV_FADE_DISTANCE_VIEWPORT_RATIO = 0.15;
+const NAV_TOP_RESET_THRESHOLD_PX = 4;
+const NAV_SCROLL_DELTA_THRESHOLD_PX = 1;
 
 type NavStyle = MotionStyle & {
   opacity: number | MotionValue<number>;
@@ -49,6 +51,13 @@ type NavStyle = MotionStyle & {
 
 function isActivePath(pathname: string, href: string) {
   return href === "/" ? pathname === href : pathname.startsWith(href);
+}
+
+function getNavFadeDistance() {
+  return Math.max(
+    window.innerHeight * NAV_FADE_DISTANCE_VIEWPORT_RATIO,
+    NAV_TOP_RESET_THRESHOLD_PX,
+  );
 }
 
 function NavLink({
@@ -173,16 +182,19 @@ export default function Navbar({ bladeUrl }: { bladeUrl: string }) {
       const scrollDelta = currentScrollY - previousScrollY.current;
       previousScrollY.current = currentScrollY;
 
-      if (currentScrollY <= 4 || scrollDelta < -1) {
+      if (
+        currentScrollY <= NAV_TOP_RESET_THRESHOLD_PX ||
+        scrollDelta < -NAV_SCROLL_DELTA_THRESHOLD_PX
+      ) {
         rawNavFadeProgress.set(0);
         return;
       }
 
-      if (scrollDelta > 1) {
+      if (scrollDelta > NAV_SCROLL_DELTA_THRESHOLD_PX) {
         rawNavFadeProgress.set(
           Math.min(
             1,
-            rawNavFadeProgress.get() + scrollDelta / NAV_FADE_DISTANCE,
+            rawNavFadeProgress.get() + scrollDelta / getNavFadeDistance(),
           ),
         );
       }

--- a/apps/club/src/app/_components/redirect.tsx
+++ b/apps/club/src/app/_components/redirect.tsx
@@ -21,7 +21,11 @@ export function Redirect({ label, target }: { label: string; target: string }) {
                 Continue
               </a>
             ) : (
-              <Link href={target} className="text-[var(--club-gold)] underline">
+              <Link
+                href={target}
+                prefetch={false}
+                className="text-[var(--club-gold)] underline"
+              >
                 Continue
               </Link>
             )}

--- a/apps/club/src/app/_components/use-deferred-section-load.ts
+++ b/apps/club/src/app/_components/use-deferred-section-load.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface DeferredSectionLoadOptions {
+  leadViewports?: number;
+}
+
+function getVerticalRootMargin(viewportHeight: number, leadViewports: number) {
+  const marginPx = Math.max(0, Math.round(viewportHeight * leadViewports));
+
+  return `${marginPx}px 0px`;
+}
+
+export function useDeferredSectionLoad<TElement extends Element>({
+  leadViewports = 0,
+}: DeferredSectionLoadOptions = {}) {
+  const [element, setElement] = useState<TElement | null>(null);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  useEffect(() => {
+    function updateViewportHeight() {
+      setViewportHeight(window.innerHeight);
+    }
+
+    updateViewportHeight();
+    window.addEventListener("resize", updateViewportHeight);
+
+    return () => window.removeEventListener("resize", updateViewportHeight);
+  }, []);
+
+  useEffect(() => {
+    if (!element || shouldLoad || viewportHeight <= 0) return;
+
+    if (!("IntersectionObserver" in window)) {
+      const fallbackId = globalThis.setTimeout(() => {
+        setShouldLoad(true);
+      }, 0);
+
+      return () => globalThis.clearTimeout(fallbackId);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+
+        setShouldLoad(true);
+        observer.disconnect();
+      },
+      {
+        rootMargin: getVerticalRootMargin(viewportHeight, leadViewports),
+      },
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [element, leadViewports, shouldLoad, viewportHeight]);
+
+  return { ref: setElement, shouldLoad };
+}

--- a/apps/club/src/app/about/page.tsx
+++ b/apps/club/src/app/about/page.tsx
@@ -87,7 +87,9 @@ function AboutButton({
           {content}
         </a>
       ) : (
-        <Link href={href}>{content}</Link>
+        <Link href={href} prefetch={false}>
+          {content}
+        </Link>
       )}
     </Button>
   );

--- a/apps/club/src/app/events/events-client.tsx
+++ b/apps/club/src/app/events/events-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ArrowUpRight,
   ChevronLeft,
@@ -12,6 +12,7 @@ import {
 import { cn } from "@forge/ui";
 
 import type { EventsStatus, PublicClubEvent } from "../_lib/club-events";
+import { useDeferredSectionLoad } from "../_components/use-deferred-section-load";
 import {
   formatEventDate,
   formatEventTime,
@@ -469,45 +470,15 @@ export function EventsClient({
   bladeUrl: string;
   eventLimit: number;
 }) {
-  const eventsSectionRef = useRef<HTMLElement>(null);
+  const { ref: eventsSectionRef, shouldLoad: shouldLoadEvents } =
+    useDeferredSectionLoad<HTMLElement>();
   const [events, setEvents] = useState<PublicClubEvent[]>([]);
   const [status, setStatus] = useState<EventsStatus>("loading");
-  const [shouldLoadEvents, setShouldLoadEvents] = useState(false);
   const [activeFilter, setActiveFilter] = useState<FilterKey>("all");
   const [calendarMonth, setCalendarMonth] =
     useState<MonthCursor>(getCurrentMonth);
   const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
   const [page, setPage] = useState(1);
-
-  useEffect(() => {
-    const eventsSection = eventsSectionRef.current;
-
-    if (!eventsSection || shouldLoadEvents) return;
-
-    if (!("IntersectionObserver" in window)) {
-      const fallbackId = globalThis.setTimeout(() => {
-        setShouldLoadEvents(true);
-      }, 0);
-
-      return () => globalThis.clearTimeout(fallbackId);
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry?.isIntersecting) return;
-
-        setShouldLoadEvents(true);
-        observer.disconnect();
-      },
-      {
-        rootMargin: "0px",
-      },
-    );
-
-    observer.observe(eventsSection);
-
-    return () => observer.disconnect();
-  }, [shouldLoadEvents]);
 
   useEffect(() => {
     if (!shouldLoadEvents) return;

--- a/apps/club/src/app/events/events-client.tsx
+++ b/apps/club/src/app/events/events-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowUpRight,
   ChevronLeft,
@@ -469,8 +469,10 @@ export function EventsClient({
   bladeUrl: string;
   eventLimit: number;
 }) {
+  const eventsSectionRef = useRef<HTMLElement>(null);
   const [events, setEvents] = useState<PublicClubEvent[]>([]);
   const [status, setStatus] = useState<EventsStatus>("loading");
+  const [shouldLoadEvents, setShouldLoadEvents] = useState(false);
   const [activeFilter, setActiveFilter] = useState<FilterKey>("all");
   const [calendarMonth, setCalendarMonth] =
     useState<MonthCursor>(getCurrentMonth);
@@ -478,6 +480,38 @@ export function EventsClient({
   const [page, setPage] = useState(1);
 
   useEffect(() => {
+    const eventsSection = eventsSectionRef.current;
+
+    if (!eventsSection || shouldLoadEvents) return;
+
+    if (!("IntersectionObserver" in window)) {
+      const fallbackId = globalThis.setTimeout(() => {
+        setShouldLoadEvents(true);
+      }, 0);
+
+      return () => globalThis.clearTimeout(fallbackId);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+
+        setShouldLoadEvents(true);
+        observer.disconnect();
+      },
+      {
+        rootMargin: "0px",
+      },
+    );
+
+    observer.observe(eventsSection);
+
+    return () => observer.disconnect();
+  }, [shouldLoadEvents]);
+
+  useEffect(() => {
+    if (!shouldLoadEvents) return;
+
     const abortController = new AbortController();
 
     async function loadEvents() {
@@ -511,7 +545,7 @@ export function EventsClient({
     void loadEvents();
 
     return () => abortController.abort();
-  }, [bladeUrl, eventLimit]);
+  }, [bladeUrl, eventLimit, shouldLoadEvents]);
 
   const filteredEvents = useMemo(
     () => events.filter((event) => eventMatchesFilter(event, activeFilter)),
@@ -555,7 +589,10 @@ export function EventsClient({
   );
 
   return (
-    <section className="club-post-hero-section relative px-6 pb-28 md:px-10 lg:px-24">
+    <section
+      ref={eventsSectionRef}
+      className="club-post-hero-section relative px-6 pb-28 md:px-10 lg:px-24"
+    >
       <div className="mx-auto max-w-[1040px]">
         <h2
           className="text-center text-4xl font-black uppercase leading-none text-white [text-shadow:4px_4px_0_rgba(0,0,0,0.5)] md:text-5xl"

--- a/apps/club/src/app/globals.css
+++ b/apps/club/src/app/globals.css
@@ -114,8 +114,9 @@ body {
   );
   box-shadow: 0 0 18px rgba(255, 182, 43, 0.48);
   pointer-events: none;
-  transform: scaleX(var(--club-scroll-progress, 0));
+  transform: translateZ(0) scaleX(var(--club-scroll-progress, 0));
   transform-origin: left;
+  will-change: transform;
 }
 
 .club-home-bg {
@@ -1655,12 +1656,8 @@ html[data-motion="ready"] .club-page-hero [data-hero-content] {
     0 0 22px rgba(255, 123, 137, 0.12);
 }
 
-.club-history-timeline-fill,
-.club-history-timeline-scrubber,
 .club-history-timeline-marker {
   transition:
-    height 140ms linear,
-    top 90ms linear,
     background-color 180ms ease,
     border-color 180ms ease,
     box-shadow 180ms ease,
@@ -1669,6 +1666,7 @@ html[data-motion="ready"] .club-page-hero [data-hero-content] {
 
 .club-history-timeline-fill {
   bottom: auto;
+  height: 100%;
   width: 6px;
   border-radius: 999px;
   background: linear-gradient(180deg, #f4ca41 0%, #ff7b89 52%, #7dd3fc 100%);
@@ -1676,6 +1674,8 @@ html[data-motion="ready"] .club-page-hero [data-hero-content] {
     0 0 0 1px rgba(255, 255, 255, 0.54),
     0 0 20px rgba(255, 123, 137, 0.34),
     0 0 42px rgba(244, 202, 65, 0.1);
+  transform-origin: top center;
+  will-change: transform;
 }
 
 .club-history-timeline-marker {
@@ -1704,11 +1704,12 @@ html[data-motion="ready"] .club-page-hero [data-hero-content] {
 
 .club-history-timeline-scrubber {
   position: absolute;
+  top: 0;
   left: 50%;
   z-index: 24;
   width: 30px;
   height: 42px;
-  transform: translate(-50%, -50%);
+  will-change: transform;
 }
 
 .club-history-timeline-scrubber::before {
@@ -2154,7 +2155,7 @@ html[data-motion="ready"] [data-stagger].is-visible > .club-team-card:hover {
 
 html[data-motion="ready"] [data-scroll-drift]:not([data-reveal]) {
   transform: translate3d(0, var(--club-scroll-drift, 0px), 0);
-  transition: transform 120ms linear;
+  transition: none;
   will-change: transform;
 }
 

--- a/apps/club/src/app/hackathons/hackathon-history.tsx
+++ b/apps/club/src/app/hackathons/hackathon-history.tsx
@@ -534,13 +534,15 @@ function Timeline({ rows }: { rows: readonly TimelineRow[] }) {
       <div
         className="club-history-timeline-fill"
         style={{
-          height: "calc(var(--history-timeline-progress, 0) * 100%)",
+          transform:
+            "translateX(-50%) scaleY(var(--history-timeline-progress, 0))",
         }}
       />
       <div
         className="club-history-timeline-scrubber"
         style={{
-          top: "clamp(21px, var(--history-timeline-scrubber-y, 0px), calc(100% - 21px))",
+          transform:
+            "translate3d(-50%, var(--history-timeline-scrubber-y, 21px), 0) translateY(-50%)",
         }}
       />
       {rows.map((row) => {

--- a/apps/club/src/app/layout.tsx
+++ b/apps/club/src/app/layout.tsx
@@ -6,6 +6,7 @@ import ClubMotionRuntime from "./_components/club-motion-runtime";
 import Footer from "./_components/footer";
 import JsonLd from "./_components/json-ld";
 import Navbar from "./_components/navbar";
+import { CLUB_ASSET_BASE_URL } from "./_lib/assets";
 import {
   OG_IMAGE_ALT,
   OG_IMAGE_HEIGHT,
@@ -28,6 +29,7 @@ const montserrat = Montserrat({
 });
 
 const bladeUrl = env.BLADE_URL;
+const clubAssetOrigin = new URL(CLUB_ASSET_BASE_URL).origin;
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -99,6 +101,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <link rel="preconnect" href={clubAssetOrigin} />
+      </head>
       <body className={`${montserrat.variable} antialiased`}>
         <ClubMotionRuntime />
         <div className="club-home-bg flex min-h-screen flex-col">

--- a/apps/club/src/app/not-found.tsx
+++ b/apps/club/src/app/not-found.tsx
@@ -30,7 +30,9 @@ export default function NotFound() {
           size="lg"
           className="club-button mt-7 min-h-[3.35rem] bg-[var(--club-gold)] text-black shadow-[4px_4px_0_#ffffff]"
         >
-          <Link href="/">Go home</Link>
+          <Link href="/" prefetch={false}>
+            Go home
+          </Link>
         </Button>
       </div>
     </main>

--- a/apps/club/src/app/sponsors/sponsors-client.tsx
+++ b/apps/club/src/app/sponsors/sponsors-client.tsx
@@ -261,7 +261,6 @@ function SponsorHighlight({
                 src={selectedSlide.imageSrc}
                 alt={selectedSlide.alt}
                 fill
-                priority={selectedIndex === 0}
                 sizes="(min-width: 1024px) 30rem, (min-width: 768px) 42vw, 88vw"
                 className="object-cover transition duration-300"
               />

--- a/apps/club/src/app/teams/teams-client.tsx
+++ b/apps/club/src/app/teams/teams-client.tsx
@@ -13,6 +13,7 @@ import { cn } from "@forge/ui";
 import { Button } from "@forge/ui/button";
 
 import type { TeamMember, TeamRoster, TeamSlug } from "./teams-config";
+import { useDeferredSectionLoad } from "../_components/use-deferred-section-load";
 import { CLUB_ASSETS } from "../_lib/assets";
 import { loadClubTeamRoster } from "./team-roster";
 import {
@@ -171,12 +172,12 @@ function EmptyTeam({ label, status }: { label: string; status: RosterStatus }) {
 }
 
 export default function TeamsClient({ bladeUrl }: { bladeUrl: string }) {
-  const rosterSectionRef = useRef<HTMLElement>(null);
+  const { ref: rosterSectionRef, shouldLoad: shouldLoadRoster } =
+    useDeferredSectionLoad<HTMLElement>();
   const pendingScrollPosition = useRef<{ x: number; y: number } | null>(null);
   const prefersReducedMotion = useReducedMotion();
   const [roster, setRoster] = useState<TeamRoster>(() => createEmptyRoster());
   const [status, setStatus] = useState<RosterStatus>("loading");
-  const [shouldLoadRoster, setShouldLoadRoster] = useState(false);
   const [activeTeam, setActiveTeam] = useState<TeamSlug>(
     TEAM_DEFINITIONS[0].slug,
   );
@@ -223,36 +224,6 @@ export default function TeamsClient({ bladeUrl }: { bladeUrl: string }) {
 
     return () => window.cancelAnimationFrame(animationFrameId);
   }, [activeTeam]);
-
-  useEffect(() => {
-    const rosterSection = rosterSectionRef.current;
-
-    if (!rosterSection || shouldLoadRoster) return;
-
-    if (!("IntersectionObserver" in window)) {
-      const fallbackId = globalThis.setTimeout(() => {
-        setShouldLoadRoster(true);
-      }, 0);
-
-      return () => globalThis.clearTimeout(fallbackId);
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry?.isIntersecting) return;
-
-        setShouldLoadRoster(true);
-        observer.disconnect();
-      },
-      {
-        rootMargin: "0px",
-      },
-    );
-
-    observer.observe(rosterSection);
-
-    return () => observer.disconnect();
-  }, [shouldLoadRoster]);
 
   useEffect(() => {
     if (!shouldLoadRoster) return;

--- a/apps/club/src/app/teams/teams-client.tsx
+++ b/apps/club/src/app/teams/teams-client.tsx
@@ -171,10 +171,12 @@ function EmptyTeam({ label, status }: { label: string; status: RosterStatus }) {
 }
 
 export default function TeamsClient({ bladeUrl }: { bladeUrl: string }) {
+  const rosterSectionRef = useRef<HTMLElement>(null);
   const pendingScrollPosition = useRef<{ x: number; y: number } | null>(null);
   const prefersReducedMotion = useReducedMotion();
   const [roster, setRoster] = useState<TeamRoster>(() => createEmptyRoster());
   const [status, setStatus] = useState<RosterStatus>("loading");
+  const [shouldLoadRoster, setShouldLoadRoster] = useState(false);
   const [activeTeam, setActiveTeam] = useState<TeamSlug>(
     TEAM_DEFINITIONS[0].slug,
   );
@@ -215,12 +217,46 @@ export default function TeamsClient({ bladeUrl }: { bladeUrl: string }) {
 
     pendingScrollPosition.current = null;
     window.scrollTo(scrollPosition.x, scrollPosition.y);
-    window.requestAnimationFrame(() => {
+    const animationFrameId = window.requestAnimationFrame(() => {
       window.scrollTo(scrollPosition.x, scrollPosition.y);
     });
+
+    return () => window.cancelAnimationFrame(animationFrameId);
   }, [activeTeam]);
 
   useEffect(() => {
+    const rosterSection = rosterSectionRef.current;
+
+    if (!rosterSection || shouldLoadRoster) return;
+
+    if (!("IntersectionObserver" in window)) {
+      const fallbackId = globalThis.setTimeout(() => {
+        setShouldLoadRoster(true);
+      }, 0);
+
+      return () => globalThis.clearTimeout(fallbackId);
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+
+        setShouldLoadRoster(true);
+        observer.disconnect();
+      },
+      {
+        rootMargin: "0px",
+      },
+    );
+
+    observer.observe(rosterSection);
+
+    return () => observer.disconnect();
+  }, [shouldLoadRoster]);
+
+  useEffect(() => {
+    if (!shouldLoadRoster) return;
+
     const abortController = new AbortController();
 
     async function loadRoster() {
@@ -240,7 +276,7 @@ export default function TeamsClient({ bladeUrl }: { bladeUrl: string }) {
     void loadRoster();
 
     return () => abortController.abort();
-  }, [bladeUrl]);
+  }, [bladeUrl, shouldLoadRoster]);
 
   function selectTeam(team: TeamSlug) {
     if (team === activeTeam) return;
@@ -330,6 +366,7 @@ export default function TeamsClient({ bladeUrl }: { bladeUrl: string }) {
       <div className="club-teams-hero-transition" aria-hidden="true" />
 
       <section
+        ref={rosterSectionRef}
         className="club-teams-post-section container pb-10 md:pb-12"
         aria-labelledby="team-members"
       >


### PR DESCRIPTION
# Why

The Club site was loading and animating more than it needed to.

Some things were happening too early, like fetching events/team data and preloading routes before the user clicked anything. Fast scrolling also felt weird because some scroll-based animations were slightly delayed instead of moving with the page right away.

This PR makes the site lighter on first load and smoother while scrolling.

# What

Closes: #473 

- Made scroll animations cheaper by caching element positions instead of checking layout on every scroll frame.
- Fixed fast-scroll drift by removing delayed transitions from scroll-linked elements.
- Delayed homepage events loading until the events section is close to the screen.
- Delayed Teams roster loading until the user scrolls to the team section.
- Turned off automatic route prefetching in the navbar and footer so the browser does not download extra pages immediately.
- Removed priority loading from carousel images since they are not the main first-screen image.
- Added a preconnect to the Club asset CDN so large remote images can start loading faster.

# Test Plan

- Ran `pnpm --filter=@forge/club format`
- Ran `pnpm --filter=@forge/club lint`
- Ran `pnpm --filter=@forge/club typecheck`
- Ran `pnpm --filter=@forge/club build`

Also checked the built site:

- Fast scroll no longer calls `getBoundingClientRect()`
- Scroll-drift elements now use `transition: none`
- Teams roster request does not fire before scrolling
- Teams roster request fires after scrolling to the section which is more optimized for network calls should help with italy loading
- Internal route prefetches stayed at `0` which is fire
- Lighthouse showed `94` Performance and `100` for Accessibility, Best Practices, and SEO which is good on local testing before deployment ngl

## Checklist

- No changes to env or db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Performance**
  - Events, teams rosters, and related sections now load only when they approach/enter the viewport.
  - Reduced unnecessary background resource prefetching for internal navigation across the site.
  - Improved scroll/animation smoothness with GPU-focused CSS tweaks and updated motion styling.

- **Improvements**
  - Refined navbar scroll-fade behavior for more consistent transitions.
  - Updated timeline animation and motion marker rendering for steadier visuals.
  - Adjusted image loading hints to better balance responsiveness and bandwidth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->