### PR TITLE
Adding Leetcode and /eightball responses

### DIFF
--- a/apps/cron/src/crons/leetcode.ts
+++ b/apps/cron/src/crons/leetcode.ts
@@ -34,6 +34,13 @@ const DAILY_MESSAGES = [
   "Let's flex your brain muscles! 💪👅😈",
   "𝓛𝓮𝓽'𝓼 𝓬𝓸𝓭𝓮 𝓿𝓻𝓸 ❤️‍🔥⛓️👅",
   "I'm 𝓯𝓻𝓮𝓪𝓴𝔂 T.K! 🛡️👅",
+  "Lock in!",
+  "Time to use 101% of your brain power! 🧠",
+  "Time to beat 100% submissions with your algorithms!",
+  "1337 1337 1337...",
+  "Rise up, coding people!",
+  "Tuff problem, you got this tho.",
+  "Leetcodemaxxing time 🥶",
 ];
 
 export const leetcode = new CronBuilder({

--- a/apps/tk/src/consts/index.ts
+++ b/apps/tk/src/consts/index.ts
@@ -110,6 +110,23 @@ export const EIGHTBALL_RESPONSES = [
   "The stars in the milky way are blinking in a decidedly good fashion!",
   "Yeah that ain't happening.",
   "Bro that's definitely happening.",
+  "Fosho.",
+  "Good question. I don't know.",
+  "I can't tell.",
+  "Yes. (trust me bro)",
+  "Of course.",
+  "No idea bro.",
+  "That seems potential.",
+  "Never. I'm telling you.",
+  "bool answer = true;",
+  "bool answer = false;",
+  "TK says no.",
+  "TK says yes.",
+  "6/7.",
+  "Lame question, sybau 💔",
+  "what 😭",
+  "yes lowkenuinely.",
+  "Based question, an insta yes from me.",
 ];
 
 export type WeatherMapKeys = Record<


### PR DESCRIPTION
# Why

Adding new prompts to TK's daily Leetcode reminders and /eightball responses.

# What

Added new prompts inside the 2 arrays `DAILY_MESSAGES` (5 new prompts) and `EIGHTBALL_RESPONSES` (11 new responses) of `forge/apps/tk/src/consts/index.ts`.

# Test Plan

Since the prompts of daily Leetcode reminders and /eightball responses are randomized (and I failed to set up the appropriate environment to start TK on my end), I want to have the bot tested in the Knight Hacks Discord server.

## Checklist

- No schema changes.
- No environment variables changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the eight-ball experience with 17 additional responses.
  * Added a broader mix of affirmative, uncertain, negative, boolean-style, and informal answers.
  * Responses now offer more variety when asking questions, including concise and playful options.
  * Added seven new messages to the LeetCode daily message rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->