### PR TITLE
api response invalidation zod cleanup

### DIFF
--- a/packages/api/src/hacker-portal/data.ts
+++ b/packages/api/src/hacker-portal/data.ts
@@ -1,3 +1,5 @@
+import type { z } from "zod";
+
 import { and, asc, eq, isNull } from "@forge/db";
 import { db } from "@forge/db/client";
 import {
@@ -10,6 +12,7 @@ import {
   HackerProfile,
   HackerProfileRevision,
 } from "@forge/db/schemas/knight-hacks";
+import { hackerProfileFieldsSchema } from "@forge/validators";
 
 import type { WriteDb } from "../utils/db";
 import { RESUME_BUCKET_NAME } from "../utils/resume/security";
@@ -119,6 +122,14 @@ export async function loadParticipantProfile(userId: string) {
   return profile ?? null;
 }
 
+function parseLegacyOptionalField<T>(
+  schema: z.ZodType<T>,
+  value: string | null,
+): T | null {
+  const result = schema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
 export function profileDto(profile: NonNullable<ParticipantProfileRow>) {
   return {
     country: profile.country,
@@ -128,18 +139,27 @@ export function profileDto(profile: NonNullable<ParticipantProfileRow>) {
     firstName: profile.firstName,
     foodAllergies: profile.foodAllergies,
     gender: profile.gender,
-    githubProfileUrl: profile.githubProfileUrl,
+    githubProfileUrl: parseLegacyOptionalField(
+      hackerProfileFieldsSchema.shape.githubProfileUrl,
+      profile.githubProfileUrl,
+    ),
     gradDate: profile.gradDate,
     lastName: profile.lastName,
     levelOfStudy: profile.levelOfStudy,
-    linkedinProfileUrl: profile.linkedinProfileUrl,
+    linkedinProfileUrl: parseLegacyOptionalField(
+      hackerProfileFieldsSchema.shape.linkedinProfileUrl,
+      profile.linkedinProfileUrl,
+    ),
     major: profile.major,
     phoneNumber: profile.phoneNumber,
     raceOrEthnicity: profile.raceOrEthnicity,
     revision: profile.revision,
     school: profile.school,
     shirtSize: profile.shirtSize,
-    websiteUrl: profile.websiteUrl,
+    websiteUrl: parseLegacyOptionalField(
+      hackerProfileFieldsSchema.shape.websiteUrl,
+      profile.websiteUrl,
+    ),
   };
 }
 

--- a/packages/api/src/tests/hacker-portal/contract.test.ts
+++ b/packages/api/src/tests/hacker-portal/contract.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { SelectHackerProfile } from "@forge/db/schemas/knight-hacks";
 import { HACKER_PARTICIPANT_V1_PROCEDURES } from "@forge/hacker-sdk/contracts";
+import { hackerProfileDtoSchema } from "@forge/validators";
 
 import { participantPayloadHash } from "../../hacker-portal/commands";
 
@@ -15,6 +17,33 @@ vi.mock("../../utils/resume/storage", () => ({
 }));
 
 describe("hacker participant v1 API contract", () => {
+  const profile = {
+    country: "United States of America",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    discordUser: "participant",
+    dob: "2005-02-14",
+    email: "participant@example.test",
+    firstName: "Portal",
+    foodAllergies: null,
+    gender: "Prefer not to answer",
+    githubProfileUrl: "https://github.com/knighthacks",
+    gradDate: "2028-05-01",
+    id: "00000000-0000-4000-8000-000000000001",
+    lastName: "Participant",
+    levelOfStudy: "Undergraduate University (3+ year)",
+    linkedinProfileUrl: "https://www.linkedin.com/in/knighthacks",
+    major: "Computer Science",
+    phoneNumber: "4075550100",
+    raceOrEthnicity: "Prefer not to answer",
+    resumeUrl: null,
+    revision: 1,
+    school: "University of Central Florida",
+    shirtSize: "M",
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    userId: "00000000-0000-4000-8000-000000000002",
+    websiteUrl: "https://knighthacks.org",
+  } satisfies SelectHackerProfile;
+
   it("implements every SDK contract procedure and no extra participant surface", async () => {
     const { hackerParticipantV1Router } =
       await import("../../hacker-portal/router");
@@ -68,6 +97,33 @@ describe("hacker participant v1 API contract", () => {
       accepted: false,
       acceptedAt: null,
       definitionId: "00000000-0000-4000-8000-000000000001",
+    });
+  });
+
+  it("omits malformed optional legacy profile links from portal responses", async () => {
+    const { profileDto } = await import("../../hacker-portal/data");
+    const dto = profileDto({
+      ...profile,
+      githubProfileUrl: "not a valid GitHub profile",
+      linkedinProfileUrl: "https://example.com/not-linkedin",
+      websiteUrl: "not a URL",
+    });
+
+    expect(dto).toMatchObject({
+      githubProfileUrl: null,
+      linkedinProfileUrl: null,
+      websiteUrl: null,
+    });
+    expect(hackerProfileDtoSchema.safeParse(dto).success).toBe(true);
+  });
+
+  it("preserves valid optional profile links in portal responses", async () => {
+    const { profileDto } = await import("../../hacker-portal/data");
+
+    expect(profileDto(profile)).toMatchObject({
+      githubProfileUrl: "https://github.com/knighthacks",
+      linkedinProfileUrl: "https://www.linkedin.com/in/knighthacks",
+      websiteUrl: "https://knighthacks.org",
     });
   });
 });


### PR DESCRIPTION
# Why

Some existing participant profiles contain malformed optional GitHub, LinkedIn, or website URLs. These legacy values caused the hacker portal’s `getApplicationContext` response validation to fail, returning HTTP 500 and displaying “Application unavailable” even when the participant had not submitted an application.

# What

- Validates optional legacy profile URLs while constructing hacker portal responses.
- Returns `null` for malformed optional URLs so the application form can still load.
- Preserves valid profile URLs.
- Keeps write-time validation strict for new profile submissions.
- Adds regression coverage confirming malformed legacy values produce a valid portal response.

No stored profile data is modified or deleted.

# Test Plan

- Verified the original failure against the affected participant’s production-backed profile.
- Confirmed the stored GitHub and website values caused response validation to fail.
- Confirmed the patched complete `getApplicationContext` response passes the exact response schema with zero validation issues.
- Confirmed the participant has no existing application and can therefore receive a blank application form.
- Ran:
  - `pnpm format`
  - `pnpm lint`
  - `pnpm typecheck`
  - `pnpm test`
  - `pnpm build`
- Added regression tests for both malformed and valid optional profile URLs.

## Checklist

- [x] Database: No schema changes, OR I ran `pnpm db:generate` and committed the generated files in `packages/db/drizzle/`
- [x] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid optional profile links are now safely returned as `null` instead of being exposed as malformed values.
  * Valid GitHub, LinkedIn, and personal website links continue to display correctly.

* **Tests**
  * Added coverage to verify profile link validation in portal responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->