### PR TITLE
Add turbo max concurrency to CI env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
         uses: ./tooling/github/setup
 
       - name: Lint
+        env:
+          # Keep concurrent ESLint processes within GitHub-hosted runner memory.
+          TURBO_CONCURRENCY: "4"
         run: pnpm lint && pnpm lint:ws
 
   format:


### PR DESCRIPTION
Lint CI step was getting killed due to max concurrency hit. This change resolves that by adding to the CI env.

- [X] Database: No schema changes, OR I ran `pnpm db:generate` and committed the generated files in `packages/db/drizzle/`
- [X] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.