### PR TITLE
[#515] Fix Club team application links

### DIFF
--- a/apps/club/src/app/teams/teams-client.tsx
+++ b/apps/club/src/app/teams/teams-client.tsx
@@ -69,7 +69,7 @@ const TEAM_APPLICATIONS = [
 ] as const;
 
 function getFormHref(bladeUrl: string, slug: string) {
-  return new URL(`/forms/${encodeURIComponent(slug)}`, bladeUrl).toString();
+  return new URL(`/form/${encodeURIComponent(slug)}`, bladeUrl).toString();
 }
 
 function getInitials(name: string) {

--- a/apps/club/src/tests/team-roster-skeleton.test.tsx
+++ b/apps/club/src/tests/team-roster-skeleton.test.tsx
@@ -37,4 +37,21 @@ describe("team roster loading placeholders", () => {
     expect(html).not.toContain('aria-label="Team filters"');
     expect(html).toContain("Loading team members");
   });
+
+  it("links team applications to Blade's singular form route", () => {
+    const html = renderToStaticMarkup(
+      createElement(TeamsClient, { bladeUrl: "http://localhost:3000" }),
+    );
+
+    for (const slug of [
+      "sponsorship-team-application",
+      "workshop-team-application",
+      "design-team-applications",
+      "outreach-team-applications",
+      "dev-team-applications",
+    ]) {
+      expect(html).toContain(`href="http://localhost:3000/form/${slug}"`);
+    }
+    expect(html).not.toContain("/forms/");
+  });
 });


### PR DESCRIPTION
# Why

Team application cards on the Club Teams page linked to Blade using
`/forms/<slug>`, which returns a Not Found page. Blade’s public form route is
`/form/<slug>`. Basically, true URL should be form/{form} not forms/{form} 

# What

Closes: #515

Updated the shared team-application URL builder to use Blade’s singular
`/form/<slug>` route, singular line change

Added regression coverage for Sponsorship, Workshop, Design, Outreach, and
Development application links. Ngl it should probably be in its own .tsx since the name of the file could be misleading for these tests as this fix does not necessarily mean "skeleton-loading"

# Test Plan

- Ran `pnpm --filter=@forge/club test` — 9 tests passed.
- Ran `pnpm analyze:react:changed` — passed.
- Ran `pnpm verify:precommit` — passed; existing repository lint warnings remain.
- Started Club locally and clicked every application card from
  `http://localhost:3001/teams`.
- Confirmed every card opens its corresponding Blade form instead of a Not
  Found page.

## Checklist

- [x] Database: No schema changes.
- [x] Environment Variables: No environment variables changed.