### PR TITLE
Fix Hacker Portal legacy profile handling and Club responsiveness

### DIFF
--- a/apps/blade/src/app/api/hacker/v1/trpc/[trpc]/route.ts
+++ b/apps/blade/src/app/api/hacker/v1/trpc/[trpc]/route.ts
@@ -1,4 +1,5 @@
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { ZodError } from "zod";
 
 import {
   createHackerPortalContext,
@@ -40,12 +41,20 @@ const handler = async (request: Request) => {
     createContext: () =>
       createHackerPortalContext({ headers: boundedRequest.headers }),
     endpoint: "/api/hacker/v1/trpc",
-    onError({ error, path }) {
+    onError({ ctx, error, path }) {
+      const validationIssues =
+        error.cause instanceof ZodError
+          ? error.cause.issues.map((issue) => ({
+              code: issue.code,
+              path: issue.path,
+            }))
+          : undefined;
       // eslint-disable-next-line no-console
-      console.error(
-        `Hacker participant tRPC error on '${path}'`,
-        error.message,
-      );
+      console.error(`Hacker participant tRPC error on '${path}'`, {
+        message: error.message,
+        requestId: ctx?.requestId,
+        validationIssues,
+      });
     },
     req: boundedRequest,
     router: hackerParticipantV1Router,

--- a/apps/club/src/app/globals.css
+++ b/apps/club/src/app/globals.css
@@ -467,6 +467,30 @@ html[data-club-static-background="true"] .club-home-bg::before {
   padding-top: var(--club-hero-logo-aligned-content-padding);
 }
 
+@media (min-width: 1024px) and (max-height: 900px) {
+  .club-history-page .club-history-hero-content {
+    top: calc(var(--club-home-hero-logo-top) - 2rem);
+  }
+
+  .club-history-hero-content .club-history-hero-eyebrow {
+    margin-bottom: 1rem;
+  }
+
+  .club-history-hero-content .club-history-hero-title {
+    font-size: 76px;
+    line-height: 0.92;
+  }
+
+  .club-history-hero-content .club-history-hero-description {
+    margin-top: 1.25rem;
+    line-height: 1.75rem;
+  }
+
+  .club-history-hero-content .club-history-hero-cta {
+    margin-top: 1.75rem;
+  }
+}
+
 .club-about-hero-content {
   padding-top: var(--club-hero-logo-aligned-content-padding);
 }

--- a/apps/club/src/app/hackathons/hackathon-history.tsx
+++ b/apps/club/src/app/hackathons/hackathon-history.tsx
@@ -673,11 +673,11 @@ export default function HackathonHistory({
         }
       >
         <div
-          className="relative z-20 mx-auto flex min-h-[calc(100svh-var(--club-nav-height))] w-full max-w-[24rem] flex-col items-center justify-start pb-10 pt-[var(--club-hero-logo-aligned-content-padding)] text-center sm:max-w-[32rem] sm:pb-14 md:max-w-[650px] md:pb-16 lg:absolute lg:left-1/2 lg:top-[var(--club-home-hero-logo-top)] lg:min-h-0 lg:w-[1060px] lg:max-w-[1060px] lg:-translate-x-1/2 lg:pb-0 lg:pt-0"
+          className="club-history-hero-content relative z-20 mx-auto flex min-h-[calc(100svh-var(--club-nav-height))] w-full max-w-[24rem] flex-col items-center justify-start pb-10 pt-[var(--club-hero-logo-aligned-content-padding)] text-center sm:max-w-[32rem] sm:pb-14 md:max-w-[650px] md:pb-16 lg:absolute lg:left-1/2 lg:top-[var(--club-home-hero-logo-top)] lg:min-h-0 lg:w-[1060px] lg:max-w-[1060px] lg:-translate-x-1/2 lg:pb-0 lg:pt-0"
           data-hero-content
           data-stagger
         >
-          <div className="mb-5 flex max-w-full flex-wrap items-center justify-center gap-3 text-[11px] font-black uppercase tracking-[0.14em] text-[var(--club-gold)] [text-shadow:3px_3px_0_rgba(0,0,0,0.52)] sm:mb-6 sm:gap-4 sm:text-[13px] sm:tracking-[0.18em] lg:gap-5">
+          <div className="club-history-hero-eyebrow mb-5 flex max-w-full flex-wrap items-center justify-center gap-3 text-[11px] font-black uppercase tracking-[0.14em] text-[var(--club-gold)] [text-shadow:3px_3px_0_rgba(0,0,0,0.52)] sm:mb-6 sm:gap-4 sm:text-[13px] sm:tracking-[0.18em] lg:gap-5">
             <span className="text-white [text-shadow:3px_3px_0_rgba(0,0,0,0.45)]">
               {yearRange}
             </span>
@@ -689,7 +689,7 @@ export default function HackathonHistory({
           </div>
           <h1
             aria-label="Knight Hacks History"
-            className="text-[clamp(2rem,9.7vw,3.65rem)] font-black uppercase leading-[0.94] tracking-normal text-white [text-shadow:5px_5px_0_rgba(0,0,0,0.48)] sm:text-[58px] md:text-[88px] md:leading-none md:[text-shadow:7px_7px_0_rgba(0,0,0,0.48)] lg:text-[96px]"
+            className="club-history-hero-title text-[clamp(2rem,9.7vw,3.65rem)] font-black uppercase leading-[0.94] tracking-normal text-white [text-shadow:5px_5px_0_rgba(0,0,0,0.48)] sm:text-[58px] md:text-[88px] md:leading-none md:[text-shadow:7px_7px_0_rgba(0,0,0,0.48)] lg:text-[96px]"
             data-reveal="headline"
           >
             <span className="club-line">
@@ -699,13 +699,13 @@ export default function HackathonHistory({
               <span className="whitespace-nowrap">History</span>
             </span>
           </h1>
-          <p className="text-white/86 mx-auto mt-5 max-w-[22rem] text-[15px] font-medium leading-7 sm:mt-6 sm:max-w-[28rem] sm:text-base sm:leading-8 md:mt-7 md:max-w-[650px] md:text-[21px] md:leading-[34px]">
+          <p className="club-history-hero-description text-white/86 mx-auto mt-5 max-w-[22rem] text-[15px] font-medium leading-7 sm:mt-6 sm:max-w-[28rem] sm:text-base sm:leading-8 md:mt-7 md:max-w-[650px] md:text-[21px] md:leading-[34px]">
             Past Knight Hacks events, project counts, and site links from
             UCF&apos;s student-built hackathons and hackdays.
           </p>
           <Link
             href="#history-timeline"
-            className="club-button mt-8 inline-flex max-w-[calc(100vw-3rem)] justify-center bg-[var(--club-gold)] text-black shadow-[4px_4px_0_rgba(255,255,255,0.85)] md:mt-10 md:shadow-[5px_5px_0_rgba(255,255,255,0.85)]"
+            className="club-button club-history-hero-cta mt-8 inline-flex max-w-[calc(100vw-3rem)] justify-center bg-[var(--club-gold)] text-black shadow-[4px_4px_0_rgba(255,255,255,0.85)] md:mt-10 md:shadow-[5px_5px_0_rgba(255,255,255,0.85)]"
           >
             Enter The Timeline
             <span aria-hidden="true" className="pl-2 text-[18px]">

--- a/apps/club/src/app/page.tsx
+++ b/apps/club/src/app/page.tsx
@@ -67,7 +67,6 @@ function HeroVideoBackground() {
         loop
         muted
         playsInline
-        poster="/hero/club-hero-poster.webp"
         preload="metadata"
       >
         <source src="/hero/club-hero.webm" type="video/webm" />

--- a/apps/khix/src/app/(portal)/apply/page.tsx
+++ b/apps/khix/src/app/(portal)/apply/page.tsx
@@ -74,11 +74,22 @@ export default function ApplyPage() {
   }
 
   return (
-    <HackerFormPage
-      applicationBackgroundKey="khix"
-      hackathonId={hackathon.data.id}
-      hackathonName={hackathon.data.displayName}
-      hackathonStartDate={hackathon.data.startDate}
-    />
+    <>
+      {(application.data.profileIssues?.length ?? 0) > 0 ? (
+        <aside className="fixed inset-x-4 top-4 z-[100] mx-auto max-w-xl rounded-lg border border-[#d7ff76]/50 bg-[#07150f]/95 p-4 text-sm leading-6 text-white shadow-2xl backdrop-blur-md">
+          <strong className="block text-[#d7ff76]">
+            Your saved profile needs an update
+          </strong>
+          Re-enter the missing profile details below before submitting your
+          application.
+        </aside>
+      ) : null}
+      <HackerFormPage
+        applicationBackgroundKey="khix"
+        hackathonId={hackathon.data.id}
+        hackathonName={hackathon.data.displayName}
+        hackathonStartDate={hackathon.data.startDate}
+      />
+    </>
   );
 }

--- a/packages/api/src/hacker-portal/data.ts
+++ b/packages/api/src/hacker-portal/data.ts
@@ -12,7 +12,10 @@ import {
   HackerProfile,
   HackerProfileRevision,
 } from "@forge/db/schemas/knight-hacks";
-import { hackerProfileFieldsSchema } from "@forge/validators";
+import {
+  hackerProfileDtoSchema,
+  hackerProfileFieldsSchema,
+} from "@forge/validators";
 
 import type { WriteDb } from "../utils/db";
 import { RESUME_BUCKET_NAME } from "../utils/resume/security";
@@ -130,7 +133,16 @@ function parseLegacyOptionalField<T>(
   return result.success ? result.data : null;
 }
 
-export function profileDto(profile: NonNullable<ParticipantProfileRow>) {
+type StoredParticipantProfileRow = Omit<
+  NonNullable<ParticipantProfileRow>,
+  "country" | "levelOfStudy" | "major"
+> & {
+  country: string;
+  levelOfStudy: string;
+  major: string;
+};
+
+function storedProfileDto(profile: StoredParticipantProfileRow) {
   return {
     country: profile.country,
     discordUser: profile.discordUser,
@@ -160,6 +172,30 @@ export function profileDto(profile: NonNullable<ParticipantProfileRow>) {
       hackerProfileFieldsSchema.shape.websiteUrl,
       profile.websiteUrl,
     ),
+  };
+}
+
+export function profileDto(profile: NonNullable<ParticipantProfileRow>) {
+  return hackerProfileDtoSchema.parse(storedProfileDto(profile));
+}
+
+export function profileDtoResult(profile: StoredParticipantProfileRow) {
+  const result = hackerProfileDtoSchema.safeParse(storedProfileDto(profile));
+  if (result.success) {
+    return { profile: result.data, profileIssues: [] };
+  }
+  return {
+    profile: null,
+    profileIssues: result.error.issues.map((issue) => ({
+      message: "This saved profile field needs to be updated.",
+      path: [
+        "profile",
+        ...issue.path.filter(
+          (part): part is number | string =>
+            typeof part === "number" || typeof part === "string",
+        ),
+      ],
+    })),
   };
 }
 

--- a/packages/api/src/hacker-portal/reads.ts
+++ b/packages/api/src/hacker-portal/reads.ts
@@ -26,7 +26,7 @@ import {
   loadParticipantApplication,
   loadParticipantProfile,
   loadResumeMetadata,
-  profileDto,
+  profileDtoResult,
   requirePortalHackathon,
 } from "./data";
 import { portalFailure } from "./trpc";
@@ -85,6 +85,9 @@ async function participantState(ctx: AuthenticatedPortalContext) {
 
 export async function getApplicationContext(ctx: AuthenticatedPortalContext) {
   const state = await participantState(ctx);
+  const profileResult = state.profile
+    ? profileDtoResult(state.profile)
+    : { profile: null, profileIssues: [] };
   const agreements = await loadActiveAgreements(
     ctx.session.hackathonId,
     "application",
@@ -108,7 +111,10 @@ export async function getApplicationContext(ctx: AuthenticatedPortalContext) {
     agreementAcceptances: agreementAcceptances.map(agreementAcceptanceDto),
     agreements: agreements.map(agreementDto),
     editable,
-    profile: state.profile ? profileDto(state.profile) : null,
+    profile: profileResult.profile,
+    ...(profileResult.profileIssues.length > 0
+      ? { profileIssues: profileResult.profileIssues }
+      : {}),
     resume: state.resume,
   };
 }
@@ -131,6 +137,9 @@ function action(
 
 export async function getDashboard(ctx: AuthenticatedPortalContext) {
   const state = await participantState(ctx);
+  const profileResult = state.profile
+    ? profileDtoResult(state.profile)
+    : { profile: null, profileIssues: [] };
   const now = new Date();
   const applicationOpen =
     now >= state.hackathon.applicationOpen &&
@@ -171,7 +180,10 @@ export async function getDashboard(ctx: AuthenticatedPortalContext) {
       ? (deriveAgeOnDate(state.profile.dob, state.hackathon.startDate) ?? 18) <
         18
       : null,
-    profile: state.profile ? profileDto(state.profile) : null,
+    profile: profileResult.profile,
+    ...(profileResult.profileIssues.length > 0
+      ? { profileIssues: profileResult.profileIssues }
+      : {}),
     resume: state.resume,
   };
 }

--- a/packages/api/src/tests/hacker-portal/contract.test.ts
+++ b/packages/api/src/tests/hacker-portal/contract.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SelectHackerProfile } from "@forge/db/schemas/knight-hacks";
 import { HACKER_PARTICIPANT_V1_PROCEDURES } from "@forge/hacker-sdk/contracts";
-import { hackerProfileDtoSchema } from "@forge/validators";
+import {
+  applicationContextDtoSchema,
+  hackerProfileDtoSchema,
+  hackerProfileFieldsSchema,
+  resumeDtoSchema,
+  resumeUploadMetadataSchema,
+} from "@forge/validators";
 
 import { participantPayloadHash } from "../../hacker-portal/commands";
 
@@ -125,5 +131,81 @@ describe("hacker participant v1 API contract", () => {
       linkedinProfileUrl: "https://www.linkedin.com/in/knighthacks",
       websiteUrl: "https://knighthacks.org",
     });
+  });
+
+  it("returns legacy profile fields without weakening profile writes", async () => {
+    const { profileDto, profileDtoResult } =
+      await import("../../hacker-portal/data");
+    const legacyProfile = {
+      ...profile,
+      dob: "0001-01-01",
+      gradDate: "0001-01-01",
+      phoneNumber: "",
+    };
+    const dto = profileDto(legacyProfile);
+    const result = profileDtoResult(legacyProfile);
+
+    expect(hackerProfileDtoSchema.safeParse(dto).success).toBe(true);
+    expect(hackerProfileFieldsSchema.safeParse(dto).success).toBe(false);
+    expect(result).toEqual({ profile: dto, profileIssues: [] });
+    expect(
+      applicationContextDtoSchema.safeParse({
+        agreementAcceptances: [],
+        agreements: [],
+        application: null,
+        editable: true,
+        profile: result.profile,
+        resume: null,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("returns a repair state instead of rejecting an incompatible legacy profile", async () => {
+    const { profileDtoResult } = await import("../../hacker-portal/data");
+    const result = profileDtoResult({
+      ...profile,
+      country: "Legacy country label",
+      major: "Legacy major label",
+    });
+
+    expect(result.profile).toBeNull();
+    expect(result.profileIssues).toEqual([
+      {
+        message: "This saved profile field needs to be updated.",
+        path: ["profile", "country"],
+      },
+      {
+        message: "This saved profile field needs to be updated.",
+        path: ["profile", "major"],
+      },
+    ]);
+    expect(
+      applicationContextDtoSchema.safeParse({
+        agreementAcceptances: [],
+        agreements: [],
+        application: null,
+        editable: true,
+        profile: result.profile,
+        profileIssues: result.profileIssues,
+        resume: null,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("reads oversized legacy resumes without weakening upload limits", () => {
+    const legacyResume = {
+      fileName: "Resume.pdf",
+      size: 8_000_000,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    expect(resumeDtoSchema.safeParse(legacyResume).success).toBe(true);
+    expect(
+      resumeUploadMetadataSchema.safeParse({
+        contentType: "application/pdf",
+        fileName: legacyResume.fileName,
+        size: legacyResume.size,
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/validators/src/hacker-portal.ts
+++ b/packages/validators/src/hacker-portal.ts
@@ -290,8 +290,27 @@ export const portalSessionDtoSchema = z
   })
   .strict();
 
+export const participantFieldIssueSchema = z
+  .object({
+    message: z.string(),
+    path: z.array(z.union([z.string(), z.number()])),
+  })
+  .strict();
+
+const storedDateOnlySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+/**
+ * Read DTOs must represent legacy profiles so yearly portals can ask users to
+ * correct them. Submission and update inputs continue to use the stricter
+ * hackerProfileFieldsSchema above.
+ */
 export const hackerProfileDtoSchema = hackerProfileFieldsSchema
-  .extend({ revision: z.number().int().min(1) })
+  .extend({
+    dob: storedDateOnlySchema,
+    gradDate: storedDateOnlySchema,
+    phoneNumber: z.string().trim().max(255),
+    revision: z.number().int().min(1),
+  })
   .strict();
 
 export const hackerApplicationDtoSchema = z
@@ -313,7 +332,7 @@ export const hackerApplicationDtoSchema = z
 export const resumeDtoSchema = z
   .object({
     fileName: z.string(),
-    size: z.number().int().min(1).max(5_000_000).nullable(),
+    size: z.number().int().min(1).nullable(),
     updatedAt: isoDateTimeSchema,
   })
   .strict();
@@ -325,6 +344,7 @@ export const applicationContextDtoSchema = z
     agreements: z.array(hackerAgreementDefinitionDtoSchema),
     editable: z.boolean(),
     profile: hackerProfileDtoSchema.nullable(),
+    profileIssues: z.array(participantFieldIssueSchema).optional(),
     resume: resumeDtoSchema.nullable(),
   })
   .strict();
@@ -352,6 +372,7 @@ export const dashboardDtoSchema = z
     application: hackerApplicationDtoSchema.nullable(),
     isMinorAtHackStart: z.boolean().nullable(),
     profile: hackerProfileDtoSchema.nullable(),
+    profileIssues: z.array(participantFieldIssueSchema).optional(),
     resume: resumeDtoSchema.nullable(),
   })
   .strict();
@@ -445,13 +466,6 @@ export const leaderboardDtoSchema = z
         .strict(),
     ),
     viewerRank: z.number().int().min(1).nullable(),
-  })
-  .strict();
-
-export const participantFieldIssueSchema = z
-  .object({
-    message: z.string(),
-    path: z.array(z.union([z.string(), z.number()])),
   })
   .strict();
 


### PR DESCRIPTION
# Why

Returning hackers with legacy profile data could receive an HTTP 500 from `getApplicationContext` because older values failed the Hacker Portal’s strict output validation. The Club landing page and Hackathon History hero also had visual issues during video loading and at increased browser zoom.

# What

- Normalized compatible legacy Hacker Portal profile values during reads.
- Return a safe profile-repair state instead of failing the entire application context.
- Preserved strict validation for new profile submissions.
- Allowed existing oversized résumé metadata to be read while retaining the 5 MB limit for new uploads.
- Added safe output-validation diagnostics without logging PII.
- Added a KHIX message that directs affected hackers to update their saved profile.
- Added regression coverage for legacy profile values, malformed optional fields, and résumé metadata.
- Removed the Club landing video’s temporary SEO poster image.
- Improved Hackathon History responsiveness at increased browser zoom.

# Test Plan

- Ran `pnpm format`.
- Ran `pnpm lint` — passed with no errors.
- Ran `pnpm typecheck` — 29/29 tasks passed.
- Ran the affected API, validator, Hacker SDK, Blade, KHIX, and Club test suites.
- Built Blade, KHIX, and Club successfully.
- Applied to KHIX with the tests on prod keys
- Ran `pnpm analyze:react:changed`.
- Verified the staged diff with `git diff --cached --check`.

## Checklist

- [x] Database: No schema changes.
- [x] Environment Variables: No environment variables changed.