### PR TITLE
[#518] Improve Club event details and date layout

### DIFF
--- a/.forge/features/club-event-details-and-date-layout/spec.md
+++ b/.forge/features/club-event-details-and-date-layout/spec.md
@@ -1,0 +1,61 @@
+# Club Event Details and Date Layout Spec
+
+Status: Approved
+
+## User-facing purpose
+
+Visitors should be able to scan upcoming Club events quickly and open any event
+to read its complete description. Dates should read as a single unit instead of
+splitting the month and weekday away from the day number.
+
+## Users / actors
+
+- Public visitors browsing Knight Hacks Club events.
+- Members deciding whether an event is relevant to them.
+
+## User-visible interface
+
+- Homepage Upcoming Events rows.
+- Calendar event cards on the Events page.
+- Upcoming Events rows on the Events page.
+- Each event keeps a compact two-line preview and gains a `View details` action.
+- The details view shows the event name, full description, date, time, location,
+  event type, and access requirement.
+- Dates appear in one block ordered as abbreviated month, large day number, then
+  abbreviated weekday.
+
+## Scope
+
+### In scope
+
+- Full event descriptions are available without relying on hover.
+- A consistent date treatment is used across all public Club event surfaces.
+- Existing event metadata, tags, access badges, loading states, error states,
+  filtering, and pagination remain intact.
+
+### Out of scope
+
+- Editing events or event descriptions from Club.
+- Adding registration, check-in, or per-event Blade links.
+- Changing Blade, the Forge API, database schemas, or event data contracts.
+- Reworking the broader Club page layout or resizing cards around one event.
+
+## Vocabulary
+
+- `Event preview`: The compact event summary shown directly in an event row.
+- `Event details`: The secondary view containing the event's complete public
+  information.
+
+## Acceptance criteria
+
+- Every populated Club event row exposes a visible `View details` action.
+- Activating `View details` reveals the full description and existing public
+  metadata while preserving the visitor's place on the page.
+- The details view supports keyboard operation and normal dismissal.
+- The month, day number, and weekday read as one date block in that order.
+- The behavior works on desktop and mobile without document overflow.
+
+## Open questions
+
+- None. The behavior and non-goals were confirmed in issue #518 and the
+  follow-up implementation request.

--- a/.forge/features/club-event-details-and-date-layout/srd.md
+++ b/.forge/features/club-event-details-and-date-layout/srd.md
@@ -1,0 +1,81 @@
+# Club Event Details and Date Layout SRD
+
+Status: Approved
+
+## Technical purpose
+
+Compose the existing public Club event data into reusable, accessible date and
+details UI used by each Club event surface.
+
+## Relevant principles
+
+- [React and Next.js principles](../../../docs/agentic-development/forge-engineering-principles.md#react-and-nextjs-principles)
+- [Sharing and package boundaries](../../../docs/agentic-development/forge-engineering-principles.md#sharing-and-package-boundaries)
+- [Frontend design skill](../../../docs/agentic-development/frontend-design-skill.md)
+
+## Access policy
+
+The surfaces and event details remain public and unauthenticated. No logged-in,
+officer, admin, or permission-based behavior is added.
+
+## Architecture / data flow
+
+`apps/club` continues to load `PublicClubEvent` records through the existing
+Blade tRPC client. New composed UI stays in `apps/club/src/app/_components`
+because it is specific to the Club theme and used only by Club. The existing
+app-agnostic dialog primitive remains in `@forge/ui` unchanged.
+
+## tRPC/API behavior
+
+No tRPC or API changes. The existing `event.getPublicClubEvents` response and
+Club normalization remain unchanged.
+
+## Validation
+
+No new inputs or data mutation. Continue rendering the normalized
+`PublicClubEvent` type without adding a validator.
+
+## Data / migration / compatibility
+
+No data, environment, configuration, or migration changes. The implementation
+can be rolled back as an isolated Club UI diff.
+
+## Discord integration
+
+None.
+
+## Configurability review
+
+Would this require a developer change next year?
+
+- Answer: No. Event content remains managed through Blade. The change only
+  controls how existing public data is presented.
+- If yes, why is hard-coding acceptable or what admin-configurable path is planned?
+  Not applicable.
+
+## React / frontend constraints
+
+- Keep pages server-side and keep interactivity inside the existing client
+  components.
+- Add no client state beyond the shared Radix dialog's state.
+- Reuse `@forge/ui/dialog`, `MarkdownContent`, Club color tokens, button
+  treatment, typography, and reduced-motion behavior.
+- Keep two-line previews as the row density strategy; show complete content in
+  a bounded, scrollable dialog.
+- The dialog needs an accessible title and description, focus management,
+  Escape dismissal, and a visible close control.
+- A reusable Club date component owns the month/day/weekday ordering across all
+  event surfaces.
+
+## Testing / verification strategy
+
+- Add Vitest coverage under `apps/club/src/tests` for semantic date ordering,
+  the accessible `View details` trigger, and complete details content.
+- Use Playwright against the local Club server to verify opening and dismissing
+  the dialog on the homepage and Events page at desktop and mobile widths.
+- Run `pnpm --filter=@forge/club test`, `pnpm analyze:react:changed`, and
+  `pnpm verify:precommit`.
+
+## Open questions
+
+- None.

--- a/.forge/features/club-event-details-and-date-layout/status.md
+++ b/.forge/features/club-event-details-and-date-layout/status.md
@@ -1,6 +1,6 @@
 # Club Event Details and Date Layout Status
 
-Current phase: Draft PR preparation
+Current phase: Draft PR open
 
 > This file is the maintained progress tracker for the feature/change. Keep it current whenever decisions, tasks, validation, or open questions change.
 
@@ -46,7 +46,7 @@ Current phase: Draft PR preparation
 
 ## Links
 
-- PRs: None.
+- PRs: https://github.com/KnightHacks/forge/pull/519
 - Issues: https://github.com/KnightHacks/forge/issues/518
 - Discord/thread context:
   - User reported truncated descriptions and disjoint date ordering with

--- a/.forge/features/club-event-details-and-date-layout/status.md
+++ b/.forge/features/club-event-details-and-date-layout/status.md
@@ -1,0 +1,53 @@
+# Club Event Details and Date Layout Status
+
+Current phase: Draft PR preparation
+
+> This file is the maintained progress tracker for the feature/change. Keep it current whenever decisions, tasks, validation, or open questions change.
+
+## Decision log
+
+- 2026-08-26: Scope confirmed from issue #518 and Chris's request to begin
+  implementation.
+- 2026-08-26: Keep two-line previews and disclose the complete event in a
+  Club-styled dialog using the shared Radix primitive.
+- 2026-08-26: Present dates as month, large day number, then weekday in one
+  reusable Club date block.
+- 2026-08-26: Keep the work inside `apps/club`; no Blade, API, database,
+  dependency, or environment changes.
+
+## Open questions
+
+- None.
+
+## Task list
+
+- [x] Complete reverse-prompting for `spec.md`.
+- [x] Complete reverse-prompting for `srd.md`.
+- [x] Complete reverse-prompting for `test-cases.md`.
+- [x] Human approves issue-backed direction and requests implementation.
+- [x] Add focused automated coverage.
+- [x] Implement the shared date block and event details dialog.
+- [x] Apply both components to all three Club event surfaces.
+- [x] Run local automated and browser validation.
+- [x] Chris reviews the local UI before commit/PR preparation.
+
+## Validation / commands
+
+- `pnpm --filter=@forge/club test`: passed, 4 files and 11 tests.
+- `pnpm analyze:react <four changed TSX files>`: passed, 4 files and 0
+  failures.
+- `pnpm verify:precommit`: passed React analysis, formatting, lint, and
+  typecheck. Lint completed with existing repository warnings and 0 errors.
+- `pnpm --filter=@forge/club build`: passed, including static generation of all
+  14 Club routes.
+- Local Playwright at 1440x1000 and 375x812: confirmed `SEP 04 FRI` order, full
+  description recovery, Escape/close dismissal, focus restoration, 44px action
+  targets, and no page or dialog horizontal overflow.
+
+## Links
+
+- PRs: None.
+- Issues: https://github.com/KnightHacks/forge/issues/518
+- Discord/thread context:
+  - User reported truncated descriptions and disjoint date ordering with
+    screenshots from the public Home and Events pages.

--- a/.forge/features/club-event-details-and-date-layout/test-cases.md
+++ b/.forge/features/club-event-details-and-date-layout/test-cases.md
@@ -1,0 +1,88 @@
+# Club Event Details and Date Layout Test Cases
+
+Status: Approved
+
+## Scope
+
+Test public event date readability, complete-description recovery, dialog
+accessibility, and preservation of existing metadata. API contracts, event
+editing, registration, and database behavior are excluded.
+
+## Test placement plan
+
+- Vitest tests live under `apps/club/src/tests` and run with
+  `pnpm --filter=@forge/club test`.
+- Browser acceptance uses the local Club server at `http://localhost:3001`.
+
+## Test cases
+
+### TC-001: Event dates read as one ordered block
+
+Setup:
+
+- A public event has a valid start date.
+
+Action:
+
+- Club renders the event date component.
+
+Expected observations:
+
+- The abbreviated month appears before the two-digit day number.
+- The abbreviated weekday appears after the day number.
+- Assistive technology receives one complete date label.
+
+### TC-002: A visitor opens complete event details
+
+Setup:
+
+- A public event has a description longer than two preview lines and includes
+  the existing public metadata.
+
+Action:
+
+- The visitor activates `View details`.
+
+Expected observations:
+
+- A dialog opens without navigating away or changing the selected calendar day.
+- The full description is readable without a line clamp.
+- The event name, date, time, location, type, and access badge are present.
+
+### TC-003: A visitor dismisses event details
+
+Setup:
+
+- The event details dialog is open.
+
+Action:
+
+- The visitor presses Escape or activates the close control.
+
+Expected observations:
+
+- The dialog closes and focus returns to the originating `View details` control.
+
+## Negative / regression cases
+
+### TC-NEG-001: Preview density and existing states remain intact
+
+Setup:
+
+- Events include a long Markdown description, and the event feed can still be
+  loading, empty, or unavailable.
+
+Action:
+
+- The visitor browses Home, Calendar, and Upcoming Events at desktop and mobile
+  widths.
+
+Expected observations:
+
+- Event rows retain compact previews and do not overflow the document.
+- Markdown links remain usable in the details dialog.
+- Existing loading, empty, and error states render unchanged.
+
+## Open questions
+
+- None.

--- a/apps/club/src/app/_components/club-event-date.tsx
+++ b/apps/club/src/app/_components/club-event-date.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@forge/ui";
+
+import { formatEventDate } from "../_lib/club-events";
+
+export function ClubEventDate({
+  className,
+  dayClassName,
+  startDateTime,
+}: {
+  className?: string;
+  dayClassName?: string;
+  startDateTime: string;
+}) {
+  const eventDate = formatEventDate(startDateTime);
+
+  return (
+    <time
+      dateTime={startDateTime}
+      className={cn(
+        "club-event-row-date flex w-fit min-w-16 flex-col items-center text-center font-black uppercase",
+        className,
+      )}
+    >
+      <span className="text-xs leading-4 text-white/65">{eventDate.month}</span>
+      <span
+        className={cn(
+          "club-event-row-day text-5xl leading-none text-white",
+          dayClassName,
+        )}
+      >
+        {eventDate.day}
+      </span>
+      <span className="mt-1 text-xs leading-4 text-white/65">
+        {eventDate.dayName}
+      </span>
+    </time>
+  );
+}

--- a/apps/club/src/app/_components/club-event-details-dialog.tsx
+++ b/apps/club/src/app/_components/club-event-details-dialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ArrowRight, Clock3, MapPin } from "lucide-react";
+
+import { Button } from "@forge/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@forge/ui/dialog";
+import { MarkdownContent } from "@forge/ui/markdown-content";
+
+import type { PublicClubEvent } from "../_lib/club-events";
+import { formatEventTime } from "../_lib/club-events";
+import { ClubEventAccessBadge } from "./club-event-access-badge";
+import { ClubEventDate } from "./club-event-date";
+
+export function ClubEventDetailsDialog({ event }: { event: PublicClubEvent }) {
+  const eventTime = formatEventTime(event.startDateTime);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="mt-2 min-h-11 rounded-none px-0 py-2 text-[11px] font-black uppercase tracking-wide text-[var(--club-gold)] hover:bg-transparent hover:text-white focus-visible:ring-[var(--club-gold)]"
+        >
+          View details
+          <ArrowRight aria-hidden="true" className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-h-[calc(100svh-2rem)] w-[calc(100%_-_2rem)] gap-0 overflow-y-auto rounded-none border-[3px] border-black bg-[#210728] p-0 text-white shadow-[8px_8px_0_rgba(255,182,43,0.85)] sm:max-w-xl [&>button]:flex [&>button]:size-11 [&>button]:items-center [&>button]:justify-center">
+        <DialogHeader className="border-b border-white/10 bg-[#59168b]/35 px-6 py-5 pr-12 text-left">
+          <p className="text-xs font-black uppercase tracking-wide text-[var(--club-gold)]">
+            {event.tag}
+          </p>
+          <DialogTitle className="text-2xl font-black leading-tight text-white sm:text-3xl">
+            {event.name}
+          </DialogTitle>
+          <DialogDescription className="text-sm text-white/65">
+            Complete event information
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-6 py-6">
+          <div className="grid gap-5 sm:grid-cols-[5rem_1fr] sm:items-center">
+            <ClubEventDate startDateTime={event.startDateTime} />
+
+            <div className="flex flex-col items-start gap-3 text-xs font-black uppercase text-[var(--club-gold)]">
+              {eventTime ? (
+                <span className="inline-flex items-center gap-2">
+                  <Clock3 aria-hidden="true" className="size-4" />
+                  {eventTime}
+                </span>
+              ) : null}
+              {event.location ? (
+                <span className="inline-flex items-start gap-2">
+                  <MapPin
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 shrink-0"
+                  />
+                  {event.location}
+                </span>
+              ) : null}
+              <ClubEventAccessBadge requiresDues={event.requiresDues} />
+            </div>
+          </div>
+
+          <MarkdownContent className="mt-6 border-t border-white/10 pt-6 text-sm leading-6 text-[var(--club-muted)] [&_a]:text-[var(--club-gold)]">
+            {event.description}
+          </MarkdownContent>
+        </div>
+
+        <DialogFooter className="border-t border-white/10 px-6 py-4">
+          <DialogClose asChild>
+            <Button
+              type="button"
+              className="club-button min-h-11 bg-[var(--club-gold)] px-6 py-2.5 text-black shadow-[3px_3px_0_rgba(255,255,255,0.85)]"
+            >
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/club/src/app/_components/home-events.tsx
+++ b/apps/club/src/app/_components/home-events.tsx
@@ -8,12 +8,10 @@ import { Button } from "@forge/ui/button";
 import { MarkdownContent } from "@forge/ui/markdown-content";
 
 import type { EventsStatus, PublicClubEvent } from "../_lib/club-events";
-import {
-  formatEventDate,
-  formatEventTime,
-  loadClubEvents,
-} from "../_lib/club-events";
+import { formatEventTime, loadClubEvents } from "../_lib/club-events";
 import { ClubEventAccessBadge } from "./club-event-access-badge";
+import { ClubEventDate } from "./club-event-date";
+import { ClubEventDetailsDialog } from "./club-event-details-dialog";
 import { useDeferredSectionLoad } from "./use-deferred-section-load";
 
 const HOME_EVENT_LIMIT = 3;
@@ -35,19 +33,19 @@ function LoadingRows({ eventLimit }: { eventLimit: number }) {
       {Array.from({ length: eventLimit }).map((_, index) => (
         <article
           key={index}
-          className="grid grid-cols-[4rem_4.5rem_1fr] items-center gap-4 border-b border-white/10 py-8 md:grid-cols-[5rem_5.5rem_1fr_15rem] md:gap-6"
+          className="grid grid-cols-[5rem_1fr] items-center gap-4 border-b border-white/10 py-8 md:grid-cols-[5.5rem_1fr_15rem] md:gap-6"
         >
-          <div className="space-y-2">
+          <div className="space-y-2 text-center">
             <div className="mx-auto h-3 w-8 animate-pulse rounded-sm bg-white/20" />
+            <div className="mx-auto h-12 w-16 animate-pulse rounded-sm bg-white/20" />
             <div className="mx-auto h-3 w-7 animate-pulse rounded-sm bg-white/15" />
           </div>
-          <div className="h-12 w-16 animate-pulse rounded-sm bg-white/20 md:h-16" />
           <div className="space-y-3">
             <div className="bg-[var(--club-gold)]/35 h-3 w-36 animate-pulse rounded-sm" />
             <div className="h-6 w-44 animate-pulse rounded-sm bg-white/20" />
             <div className="h-4 max-w-[21rem] animate-pulse rounded-sm bg-white/15" />
           </div>
-          <div className="col-span-3 hidden aspect-[1.65] animate-pulse rounded-lg bg-[#59168b]/55 md:col-span-1 md:block" />
+          <div className="col-span-2 hidden aspect-[1.65] animate-pulse rounded-lg bg-[#59168b]/55 md:col-span-1 md:block" />
         </article>
       ))}
     </div>
@@ -55,19 +53,15 @@ function LoadingRows({ eventLimit }: { eventLimit: number }) {
 }
 
 function EventRow({ event }: { event: PublicClubEvent }) {
-  const eventDate = formatEventDate(event.startDateTime);
   const eventTime = formatEventTime(event.startDateTime);
   const meta = [eventTime, event.location].filter(Boolean).join(" | ");
 
   return (
-    <article className="club-event-row grid grid-cols-[4rem_4.5rem_1fr] items-center gap-4 border-b border-white/10 py-8 md:grid-cols-[5rem_5.5rem_1fr_15rem] md:gap-6">
-      <div className="club-event-row-date text-center text-xs font-bold uppercase leading-4 text-white/70">
-        <p>{eventDate.month}</p>
-        <p>{eventDate.dayName}</p>
-      </div>
-      <p className="club-event-row-day text-5xl font-black leading-none text-white md:text-6xl">
-        {eventDate.day}
-      </p>
+    <article className="club-event-row grid grid-cols-[5rem_1fr] items-center gap-4 border-b border-white/10 py-8 md:grid-cols-[5.5rem_1fr_15rem] md:gap-6">
+      <ClubEventDate
+        startDateTime={event.startDateTime}
+        dayClassName="md:text-6xl"
+      />
       <div className="club-event-row-copy">
         <p className="text-xs font-bold uppercase text-[var(--club-gold)]">
           {meta}
@@ -84,9 +78,10 @@ function EventRow({ event }: { event: PublicClubEvent }) {
         >
           {event.description}
         </MarkdownContent>
+        <ClubEventDetailsDialog event={event} />
       </div>
       <div
-        className="club-event-tag-card col-span-3 hidden aspect-[1.65] items-center justify-center rounded-lg px-5 text-center md:col-span-1 md:flex"
+        className="club-event-tag-card col-span-2 hidden aspect-[1.65] items-center justify-center rounded-lg px-5 text-center md:col-span-1 md:flex"
         style={{ backgroundColor: `${event.tagColor}55` }}
       >
         <span className="text-white/72 text-xs font-black uppercase">

--- a/apps/club/src/app/events/events-client.tsx
+++ b/apps/club/src/app/events/events-client.tsx
@@ -14,9 +14,10 @@ import { MarkdownContent } from "@forge/ui/markdown-content";
 
 import type { EventsStatus, PublicClubEvent } from "../_lib/club-events";
 import { ClubEventAccessBadge } from "../_components/club-event-access-badge";
+import { ClubEventDate } from "../_components/club-event-date";
+import { ClubEventDetailsDialog } from "../_components/club-event-details-dialog";
 import { useDeferredSectionLoad } from "../_components/use-deferred-section-load";
 import {
-  formatEventDate,
   formatEventTime,
   formatMonthLabel,
   getClubCurrentMonth,
@@ -308,19 +309,9 @@ function CalendarPanel({
 }
 
 function CalendarEventCard({ event }: { event: PublicClubEvent }) {
-  const eventDate = formatEventDate(event.startDateTime);
-
   return (
     <article className="club-event-row grid gap-5 border-b border-white/10 bg-[#5b164d]/35 p-5 first:rounded-lg first:border-b-0 first:bg-[#6a1b57]/65 md:grid-cols-[5.25rem_1fr]">
-      <div className="club-event-row-date flex items-center gap-3 md:block">
-        <div className="text-xs font-black uppercase leading-4 text-white/60">
-          <p>{eventDate.month}</p>
-          <p>{eventDate.dayName}</p>
-        </div>
-        <p className="club-event-row-day text-5xl font-black leading-none text-white">
-          {eventDate.day}
-        </p>
-      </div>
+      <ClubEventDate startDateTime={event.startDateTime} />
       <div className="club-event-row-copy">
         <EventMeta event={event} />
         <h3 className="mt-2 text-2xl font-black leading-tight text-white">
@@ -332,6 +323,7 @@ function CalendarEventCard({ event }: { event: PublicClubEvent }) {
         >
           {event.description}
         </MarkdownContent>
+        <ClubEventDetailsDialog event={event} />
       </div>
     </article>
   );
@@ -383,22 +375,12 @@ function UpcomingSkeleton() {
 }
 
 function UpcomingEventRow({ event }: { event: PublicClubEvent }) {
-  const eventDate = formatEventDate(event.startDateTime);
-
   return (
-    <article className="club-event-row grid gap-5 border-b border-white/10 py-8 md:grid-cols-[5rem_5rem_1fr_13rem] md:items-center md:gap-7">
-      <div className="club-event-row-date flex items-center gap-3 md:block md:text-center">
-        <div className="text-xs font-black uppercase leading-4 text-white/55">
-          <p>{eventDate.month}</p>
-          <p>{eventDate.dayName}</p>
-        </div>
-        <p className="club-event-row-day text-5xl font-black leading-none text-white md:hidden">
-          {eventDate.day}
-        </p>
-      </div>
-      <p className="club-event-row-day hidden text-6xl font-black leading-none text-white md:block">
-        {eventDate.day}
-      </p>
+    <article className="club-event-row grid gap-5 border-b border-white/10 py-8 md:grid-cols-[5.5rem_1fr_13rem] md:items-center md:gap-7">
+      <ClubEventDate
+        startDateTime={event.startDateTime}
+        dayClassName="md:text-6xl"
+      />
       <div className="club-event-row-copy">
         <EventMeta event={event} />
         <h3 className="mt-2 text-2xl font-black leading-tight text-white">
@@ -410,6 +392,7 @@ function UpcomingEventRow({ event }: { event: PublicClubEvent }) {
         >
           {event.description}
         </MarkdownContent>
+        <ClubEventDetailsDialog event={event} />
       </div>
       <div
         className="club-event-tag-card flex min-h-24 items-center justify-center rounded-lg px-5 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] md:min-h-28"

--- a/apps/club/src/tests/club-event-display.test.tsx
+++ b/apps/club/src/tests/club-event-display.test.tsx
@@ -1,0 +1,42 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { PublicClubEvent } from "../app/_lib/club-events";
+import { ClubEventDate } from "../app/_components/club-event-date";
+import { ClubEventDetailsDialog } from "../app/_components/club-event-details-dialog";
+
+const event: PublicClubEvent = {
+  id: "00000000-0000-4000-8000-000000000518",
+  name: "Fall Kickoff",
+  description:
+    "Join us for the first GBM of the semester. [Read the agenda](https://example.com/agenda).",
+  startDateTime: "2026-09-04T20:00:00.000Z",
+  endDateTime: "2026-09-04T22:00:00.000Z",
+  location: "Key West Ballroom (SU 218)",
+  requiresDues: false,
+  tag: "GBM",
+  tagColor: "#2563EB",
+};
+
+describe("Club event display", () => {
+  it("TC-001 renders the month, day, and weekday as one semantic date block", () => {
+    const html = renderToStaticMarkup(
+      createElement(ClubEventDate, {
+        startDateTime: event.startDateTime,
+      }),
+    );
+
+    expect(html).toContain('<time dateTime="2026-09-04T20:00:00.000Z"');
+    expect(html).toMatch(/>Sep<\/span>.*>04<\/span>.*>Fri<\/span>/);
+  });
+
+  it("TC-002 exposes an accessible action for the complete event details", () => {
+    const html = renderToStaticMarkup(
+      createElement(ClubEventDetailsDialog, { event }),
+    );
+
+    expect(html).toContain(">View details<");
+    expect(html).toContain("button");
+  });
+});


### PR DESCRIPTION
# Why

Club event cards limit descriptions to two lines, so people could not read
longer event details. The date also split the month and weekday from the day
number, which made dates such as `SEP FRI 04` harder to read.

# What

Closes: #518

- Added a `View details` action to the homepage, Calendar cards, and Upcoming
  Events rows.
- Added a Club-styled dialog that shows the full Markdown description, date,
  time, location, event type, and dues requirement.
- Reworked the shared date display so the month, day number, and weekday read as
  one block: `SEP`, `04`, `FRI`.
- Kept the changes inside Club and reused the existing `@forge/ui` dialog.

# Test Plan

- Ran `pnpm --filter=@forge/club test`: 11 tests passed.
- Ran `pnpm verify:precommit`: React analysis, formatting, lint, and typecheck
  passed. Existing repository lint warnings remain.
- Ran `pnpm --filter=@forge/club build`: all 14 Club routes generated.
- Tested the homepage and Events page locally at desktop and mobile widths.
- Confirmed the full Fall Kickoff description is available in the dialog.
- Confirmed Escape and both close controls dismiss the dialog and return focus
  to `View details`.
- Confirmed the page and dialog have no horizontal overflow at 1440x1000 and
  375x812.

## Screenshots

Before: 
<img width="837" height="300" alt="image" src="https://github.com/user-attachments/assets/9d9ca673-b8e2-4541-ba29-ef942159202c" />

After: 

<img width="856" height="421" alt="image" src="https://github.com/user-attachments/assets/ecab1e8f-9559-4d0d-ab4c-202950b39936" />


<img width="1440" height="1000" alt="Clubeevent" src="https://github.com/user-attachments/assets/f4b195c3-1d78-4834-916b-f4fe4f8767e4" />
<img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/c915f1a5-ada3-42b1-8bb3-aba13937ab5e" />


## Checklist

- [x] Database: No schema changes.
- [x] Environment Variables: No environment variables changed.
