### PR TITLE
[#546] Guide hackathon event editors through tag setup

### DIFF
--- a/apps/blade/src/app/_components/admin/hackathon-events/hackathon-events-workspace.tsx
+++ b/apps/blade/src/app/_components/admin/hackathon-events/hackathon-events-workspace.tsx
@@ -446,6 +446,7 @@ export function HackathonEventsWorkspace({
 
   const tagItems = (tags.data ?? []) satisfies EventTagItem[];
   const activeTags = tagItems.filter(({ active }) => active);
+  const canCreateEvent = activeTags.length > 0;
 
   function latestParams() {
     const committed = searchParams.toString();
@@ -678,15 +679,19 @@ export function HackathonEventsWorkspace({
                 ) : null}
                 <Button
                   className="min-h-11 gap-2"
-                  disabled={!selectedHackathon || activeTags.length === 0}
-                  onClick={() => openForm("create")}
-                  title={
-                    activeTags.length === 0
-                      ? "Create or import an active event tag first."
-                      : undefined
+                  disabled={!selectedHackathon || tags.isPending}
+                  onClick={() =>
+                    canCreateEvent
+                      ? openForm("create")
+                      : navigate({ page: null, view: "tags" })
                   }
                 >
-                  <Plus className="size-4" aria-hidden="true" /> Create event
+                  {canCreateEvent ? (
+                    <Plus className="size-4" aria-hidden="true" />
+                  ) : (
+                    <Tags className="size-4" aria-hidden="true" />
+                  )}
+                  {canCreateEvent ? "Create event" : "Set up event tags"}
                 </Button>
               </>
             ) : null}

--- a/apps/blade/src/tests/e2e/hackathon-events.spec.ts
+++ b/apps/blade/src/tests/e2e/hackathon-events.spec.ts
@@ -178,6 +178,30 @@ test.describe("Hackathon event and check-in critical flow", () => {
 
   test.afterAll(cleanupFixtures);
 
+  test("guides event editors through required tag setup", async ({ page }) => {
+    await db
+      .update(EventTag)
+      .set({ active: false })
+      .where(eq(EventTag.id, TAG_ID));
+    try {
+      await page.goto(
+        `/api/e2e/signin?userId=${ADMIN_ID}&callbackURL=${encodeURIComponent(`/admin/hackathon-events?hackathon=${HACKATHON_ID}`)}`,
+      );
+      await page
+        .getByRole("button", { name: "Set up event tags", exact: true })
+        .click();
+      await expect(page).toHaveURL(/view=tags/);
+      await expect(
+        page.getByRole("heading", { name: "Event tags" }),
+      ).toBeVisible();
+    } finally {
+      await db
+        .update(EventTag)
+        .set({ active: true })
+        .where(eq(EventTag.id, TAG_ID));
+    }
+  });
+
   test("keeps linked hack tag identity after rename and an unrelated event edit", async ({
     page,
   }) => {


### PR DESCRIPTION
# Why

Knight Hacks IX has the required event permissions but no event tags. Blade disabled the Create event action in that state, leaving editors without a usable path to satisfy the prerequisite.

# What

Closes: #546

When a hackathon has no active event tags, the primary action now reads Set up event tags and opens the tag-management section. Once an active tag exists, the same action creates an event as before. Cached active tags remain usable if a background refetch fails.

# Test Plan

- Ran the focused Playwright regression for required tag setup: 1 passed.
- Ran pnpm verify:precommit: React analysis, formatting, lint, and typecheck passed.
- Ran the standard Forge review tier for React behavior and test quality; no findings remain.
- Screenshot not included because this changes the primary action label and destination only; the Playwright test exercises the rendered control and destination heading.

## Checklist

- [x] Database: No schema changes, OR I ran pnpm db:generate and committed the generated files in packages/db/drizzle/
- [x] Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.