### PR TITLE
Khix/hacker guide

### DIFF
--- a/apps/2026/src/app/(portal)/_components/khix-dashboard.tsx
+++ b/apps/2026/src/app/(portal)/_components/khix-dashboard.tsx
@@ -467,7 +467,10 @@ export function KhixDashboard({ sessionUser }: KhixDashboardProps) {
           headline="Looks like you haven't applied yet."
           greeting={`Hi, ${fallbackName}!`}
         />
-        <ToolDock supportUrl={config.copy.supportChannelUrl} />
+        <ToolDock
+          guideUrl={config.guideUrl}
+          supportUrl={config.copy.supportChannelUrl}
+        />
       </KhixDashboardShell>
     );
   }
@@ -530,6 +533,7 @@ export function KhixDashboard({ sessionUser }: KhixDashboardProps) {
             atCapacity={atCapacity}
             confirmationClosed={confirmationClosed}
             agreements={confirmationAgreements}
+            guideUrl={config.guideUrl}
             loadQRCode={loadQRCode}
             onConfirm={handleConfirm}
             onWithdraw={handleWithdraw}
@@ -586,6 +590,7 @@ export function KhixDashboard({ sessionUser }: KhixDashboardProps) {
         qrLoading={qrMutation.isPending}
         loadQRCode={loadQRCode}
         hideApplications={participant.status === "checkedin"}
+        guideUrl={config.guideUrl}
         supportUrl={config.copy.supportChannelUrl}
       />
     </KhixDashboardShell>
@@ -3636,6 +3641,7 @@ function StatusAction({
   agreements,
   atCapacity,
   confirmationClosed,
+  guideUrl,
   loadQRCode,
   onConfirm,
   onWithdraw,
@@ -3649,6 +3655,7 @@ function StatusAction({
   agreements: HackerAgreementDefinitionDto[];
   atCapacity: boolean;
   confirmationClosed: boolean;
+  guideUrl: string;
   loadQRCode: () => Promise<unknown>;
   onConfirm: (agreements: HackerAgreementAcceptanceInput[]) => Promise<void>;
   onWithdraw: () => Promise<void>;
@@ -3812,13 +3819,10 @@ function StatusAction({
           Join Discord <ExternalLink className="size-4" />
         </a>
       </Button>
-      <Button
-        variant="outline"
-        className={styles.ghostButton}
-        disabled
-        type="button"
-      >
-        Hackers guide <LockKeyhole className="size-4" />
+      <Button asChild variant="outline" className={styles.ghostButton}>
+        <a href={guideUrl} target="_blank" rel="noopener noreferrer">
+          Hackers guide <ExternalLink className="size-4" />
+        </a>
       </Button>
     </>
   );
@@ -4102,6 +4106,7 @@ function RemoveResumeDialog({
 }
 
 function ToolDock({
+  guideUrl,
   hideApplications = false,
   loadQRCode,
   qrAvailable,
@@ -4113,6 +4118,7 @@ function ToolDock({
   resumeUrl,
   supportUrl,
 }: {
+  guideUrl: string;
   hideApplications?: boolean;
   loadQRCode?: () => Promise<unknown>;
   qrAvailable?: boolean;
@@ -4134,11 +4140,12 @@ function ToolDock({
       aria-label="Dashboard links"
     >
       <ActionTile
-        description="Rules, arrival notes, and prep open closer to Knight Hacks IX."
-        icon={<LockKeyhole className="size-4" />}
+        description="Rules, arrival notes, and everything you need to prepare."
+        href={guideUrl}
+        icon={<BookOpen className="size-4" />}
         label="Hackers guide"
-        meta="Locked"
-        disabled
+        meta="Open"
+        external
       />
       {!hideApplications && (
         <>

--- a/apps/2026/src/lib/portal-config.ts
+++ b/apps/2026/src/lib/portal-config.ts
@@ -8,7 +8,8 @@ export const KHIX_PORTAL_CONFIG = {
     profile: "/dashboard/profile",
   },
   termsUrl: "https://knight-hacks.notion.site/knight-hacks-26-tos",
-  guideUrl: "https://knight-hacks.notion.site/knighthacksix",
+  guideUrl:
+    "https://app.notion.com/p/knight-hacks/Knight-Hacks-IX-Hackers-Guide-334e290ccffe80e39ec7ee1e20a33bae?source=copy_link",
   copy: {
     applicationName: "Knight Hacks IX",
     supportChannelUrl: "https://discord.knighthacks.org/",

--- a/apps/2026/src/lib/portal-config.ts
+++ b/apps/2026/src/lib/portal-config.ts
@@ -8,8 +8,7 @@ export const KHIX_PORTAL_CONFIG = {
     profile: "/dashboard/profile",
   },
   termsUrl: "https://knight-hacks.notion.site/knight-hacks-26-tos",
-  guideUrl:
-    "https://app.notion.com/p/knight-hacks/Knight-Hacks-IX-Hackers-Guide-334e290ccffe80e39ec7ee1e20a33bae?source=copy_link",
+  guideUrl: "https://knight-hacks.notion.site/knight-hacks-ix-hackers-guide",
   copy: {
     applicationName: "Knight Hacks IX",
     supportChannelUrl: "https://discord.knighthacks.org/",


### PR DESCRIPTION
Why
Hackers need a clear and accessible way to open the Knight Hacks IX Hacker’s Guide from the portal.
What
- Unlocked the Hacker’s Guide dashboard card and tool dock shortcut.
- Linked both entry points to the centralized portal configuration.
- Updated the guide URL to the public Notion page.
- Configured the guide to open safely in a new tab.
Test Plan
- Verified both Hacker’s Guide entry points open the correct public Notion page.
- Tested the dashboard on desktop and mobile layouts.
- Confirmed all 14 KHIX tests pass.
- Confirmed formatting, lint, and TypeScript checks pass.
Checklist
- Database: No schema changes, OR I ran pnpm db:generate and committed the generated files in packages/db/drizzle/
- Environment Variables: No environment variables changed, OR I have contacted the Development Lead to modify them on Coolify BEFORE merging.